### PR TITLE
Replace AES with SANSE

### DIFF
--- a/kravatte/sanse.go
+++ b/kravatte/sanse.go
@@ -83,16 +83,16 @@ func (s *sanse) Open(dst, nonce, ciphertext, additionalData []byte) ([]byte, err
 }
 
 // NewSANSE returns a SANSE implementation of cipher.AEAD. It has a NonceSize of
-// 0 and an Overhead of TagSize. The implementation is ported from XKCP.
-func NewSANSE(key []byte) cipher.AEAD {
-	s := &sanse{
+// 0 and an Overhead of TagSize.
+func NewSANSE(key []byte) (cipher.AEAD, error) {
+	s := sanse{
 		kravatte: Kravatte{},
 		e:        0,
 	}
 	if s.kravatte.RefMaskInitialize(key) != 0 {
-		panic("unable to initialize kravatte")
+		return nil, errors.New("invalid key")
 	}
-	return s
+	return &s, nil
 }
 
 func memxoris(target, source []byte, bitLen int) {

--- a/kravatte/sanse_test.go
+++ b/kravatte/sanse_test.go
@@ -157,8 +157,10 @@ func TestAEAD(t *testing.T) {
 		},
 	}
 	key := newTestKey(32)
-	initiator := NewSANSE(key)
-	responder := NewSANSE(key)
+	initiator, err := NewSANSE(key)
+	assert.NilError(t, err)
+	responder, err := NewSANSE(key)
+	assert.NilError(t, err)
 	var associatedData [1]byte
 
 	runTranscript := func(alias bool) func(t *testing.T) {

--- a/transport/common.go
+++ b/transport/common.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 
 	"golang.org/x/crypto/curve25519"
+	"zmap.io/portal/kravatte"
 )
 
 // ProtocolName is the string representation of the parameters used in this version
@@ -14,11 +15,13 @@ const Version byte = 0x01
 
 // Protocol size constants
 const (
-	HeaderLen    = 4
-	MacLen       = 16
+	HeaderLen = 4
+	MacLen    = 16
+	// TODO(dadrian): It's confusing to have MacLen and tag len
+	TagLen       = 32
 	KeyLen       = 16
 	DHLen        = curve25519.PointSize
-	CookieLen    = 32 + 12 + 16 // 32 bytes of secret, 12 bytes of nonce, 16 bytes of GCM tag
+	CookieLen    = DHLen + kravatte.TagSize
 	SNILen       = 256
 	SessionIDLen = 4
 	CounterLen   = 8

--- a/transport/duplex.go
+++ b/transport/duplex.go
@@ -22,6 +22,7 @@ func (s *Server) ReplayDuplexFromCookie(cookie, clientEphemeral []byte, clientAd
 	// Pull the private key out of the cookie
 	n, err := out.decryptCookie(cookie)
 	if err != nil {
+		logrus.Errorf("unable to decrypt cookie: %s", err)
 		return nil, err
 	}
 	if n != CookieLen {

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -2,13 +2,11 @@ package transport
 
 import (
 	"bytes"
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
 	"io"
 	"net"
 
 	"github.com/sirupsen/logrus"
+	"zmap.io/portal/kravatte"
 )
 
 // SessionID is an IP-independent identifier of a tunnel.
@@ -33,8 +31,7 @@ type SessionState struct {
 // transport message. It returns a negative number for transport messages of
 // insufficient length to contain any plaintext.
 func PlaintextLen(transportLen int) int {
-	// TODO(dadrian): remove the 12-byte nonce when we get rid of AES
-	return transportLen - HeaderLen - SessionIDLen - CounterLen - MacLen - 12
+	return transportLen - HeaderLen - SessionIDLen - CounterLen - TagLen
 }
 
 // PeekSession returns the SessionID located in the provided raw transport
@@ -88,7 +85,7 @@ func (ss *SessionState) readCounter(b []byte) (count uint64) {
 }
 
 func (ss *SessionState) writePacket(conn *net.UDPConn, in []byte, key *[KeyLen]byte) error {
-	length := HeaderLen + SessionIDLen + CounterLen + len(in) + MacLen + 12
+	length := HeaderLen + SessionIDLen + CounterLen + len(in) + TagLen
 	ss.rawWrite.Reset()
 	if ss.rawWrite.Cap() < length {
 		ss.rawWrite.Grow(length)
@@ -106,28 +103,19 @@ func (ss *SessionState) writePacket(conn *net.UDPConn, in []byte, key *[KeyLen]b
 	ss.writeCounter(&ss.rawWrite)
 	logrus.Debugf("ss: writing packet with count %d", ss.count)
 
-	// Temporary Encryption via AES until Kravatte is working
-	// TODO(dadrian): Finish Kravatte and get rid of AES.
-	block, err := aes.NewCipher(key[:])
+	// Encrypt the message. The associated data is the message header. There is
+	// no nonce. The output has an overhead of TagLength.
+	aead, err := kravatte.NewSANSE(key[:])
 	if err != nil {
 		return err
 	}
-	aead, err := cipher.NewGCMWithTagSize(block, MacLen)
-	if err != nil {
-		return err
-	}
-	buf := make([]byte, 12+MacLen+len(in))
-	if n, err := rand.Read(buf[0:12]); err != nil || n != 12 {
-		panic("could not read random nonce for transport")
-	}
-	enc := aead.Seal(buf[12:12], buf[:12], in, ss.rawWrite.Bytes()[:AssociatedDataLen])
+	buf := make([]byte, TagLen+len(in))
+	enc := aead.Seal(buf[:0], nil, in, ss.rawWrite.Bytes()[:AssociatedDataLen])
 	logrus.Debugf("write: %x %x", buf[:12], enc)
 	logrus.Debugf("write(buf): %x", buf)
-	if len(enc)+12 != len(buf) {
-		logrus.Panicf("expected len(buf) = len(enc) + 12, got: %d = %d + 12", len(buf), len(enc))
+	if len(enc) != len(buf) {
+		logrus.Panicf("expected len(buf) = len(enc), got: %d = %d + 12", len(buf), len(enc))
 	}
-
-	// TODO(dadrian): Encryption
 	ss.rawWrite.Write(buf)
 
 	b := ss.rawWrite.Bytes()
@@ -145,7 +133,7 @@ func (ss *SessionState) writePacket(conn *net.UDPConn, in []byte, key *[KeyLen]b
 
 func (ss *SessionState) readPacket(plaintext, pkt []byte, key *[KeyLen]byte) (int, error) {
 	plaintextLen := PlaintextLen(len(pkt))
-	ciphertextLen := plaintextLen + MacLen
+	ciphertextLen := plaintextLen + TagLen
 	if plaintextLen > len(plaintext) {
 		return 0, ErrBufOverflow
 	}
@@ -171,29 +159,23 @@ func (ss *SessionState) readPacket(plaintext, pkt []byte, key *[KeyLen]byte) (in
 	logrus.Debugf("ss: read packet with count %d", count)
 	b = b[CounterLen:]
 
-	// Temporary Encryption via AES until Kravatte is working
-	// TODO(dadrian): Finish Kravatte and get rid of AES.
-	block, err := aes.NewCipher(key[:])
+	aead, err := kravatte.NewSANSE(key[:])
 	if err != nil {
 		return 0, err
 	}
-	aead, err := cipher.NewGCMWithTagSize(block, MacLen)
-	if err != nil {
-		return 0, err
-	}
-	nonce := b[:12]
-	b = b[12:]
 	enc := b[:ciphertextLen]
-	logrus.Debugf("read: %x %x", nonce, enc)
-	out, err := aead.Open(plaintext[:0], nonce, enc, pkt[:AssociatedDataLen])
+	logrus.Debugf("read enc: %x", enc)
+	b = b[ciphertextLen:]
+	if len(b) != 0 {
+		logrus.Panicf("len(b) = %d, expected 0", len(b))
+	}
+	out, err := aead.Open(plaintext[:0], nil, enc, pkt[:AssociatedDataLen])
 	if err != nil {
 		return 0, err
 	}
 	if len(out) != plaintextLen {
-		panic("wtf mate")
+		logrus.Panicf("len(out) = %d, expected plaintextLen = %d", len(out), plaintextLen)
 	}
-	// b = b[plaintextLen:]
-	// b = b[MacLen:] // Mac checked as part of Open
 
 	return plaintextLen, nil
 }

--- a/transport/transport_test.go
+++ b/transport/transport_test.go
@@ -1,0 +1,16 @@
+package transport
+
+import (
+	"testing"
+
+	"gotest.tools/assert"
+	"gotest.tools/assert/cmp"
+	"zmap.io/portal/kravatte"
+)
+
+func TestTransportAEAD(t *testing.T) {
+	key := []byte{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31}
+	sanse, err := kravatte.NewSANSE(key[:])
+	assert.NilError(t, err)
+	assert.Check(t, cmp.Equal(sanse.Overhead(), TagLen))
+}


### PR DESCRIPTION
This replaces the temporary use of AES-GCM for transport messages with Deck-SANSE. We do not use a nonce, and instead rely on the counter in the associated data.