### PR TITLE
Let command line port/user override config port/user

### DIFF
--- a/cmd/hop/main.go
+++ b/cmd/hop/main.go
@@ -31,7 +31,7 @@ func main() {
 	cc.HandshakeTimeout = 15 * time.Second
 	cc.DataTimeout = 15 * time.Second
 
-	client, err := hopclient.NewHopClientOverride(cc, f.Address)
+	client, err := hopclient.NewHopClientWithURL(cc, f.Address)
 	if err != nil {
 		logrus.Error(err)
 		return

--- a/hopclient/hopclient.go
+++ b/hopclient/hopclient.go
@@ -56,13 +56,13 @@ type HopClient struct { // nolint:maligned
 
 // NewHopClient creates a new client object
 func NewHopClient(config *config.ClientConfig, hostname string) (*HopClient, error) {
-	return NewHopClientOverride(config, &core.URL{Host: hostname})
+	return NewHopClientWithURL(config, &core.URL{Host: hostname})
 }
 
-// NewHopClientOverride creates a new client object, like NewHopClient, but
+// NewHopClientWithURL creates a new client object, like NewHopClient, but
 // takes in a core.URL to allow overriding the port/user for the hostconfig
 // matching host.Host
-func NewHopClientOverride(config *config.ClientConfig, host *core.URL) (*HopClient, error) {
+func NewHopClientWithURL(config *config.ClientConfig, host *core.URL) (*HopClient, error) {
 	client := &HopClient{
 		config:     config,
 		hostconfig: config.MatchHost(host.Host),


### PR DESCRIPTION
Fixes #61; namely, we let the port/user specified in the command line override that specified by the host config.