### PR TITLE
Try to add all user groups before launching command

### DIFF
--- a/hopserver/session.go
+++ b/hopserver/session.go
@@ -263,6 +263,8 @@ func getGroups(uid int) (groups []uint32) {
 		parsed, err := strconv.ParseUint(gid, 10, 32)
 		if err == nil {
 			groups = append(groups, uint32(parsed))
+		} else {
+			logrus.Infof("Failed to parse gid %v (error: %v)", gid, err)
 		}
 	}
 	return


### PR DESCRIPTION
Instead of setting the user's groups to be just their gid, try to add all other groups that the user is a part of. If we can't add all the groups, it's probably better to at least give their gid--giving too few is better than giving too many (and it's probably still useful to be able to log in even with just the subset).