### PR TITLE
transport: fix Close() race conditions and add concurrency invariant tests

### DIFF
--- a/transport/client.go
+++ b/transport/client.go
@@ -56,7 +56,16 @@ type Client struct {
 
 	config ClientConfig
 
-	closeWg sync.WaitGroup
+	// closeDone is closed exactly once (guarded by closeOnce) when the
+	// connection has been fully torn down. Concurrent callers of Close that lose
+	// the race to perform the teardown block on it so that Close never returns
+	// before the connection is safely closed.
+	closeOnce sync.Once
+	closeDone chan struct{}
+}
+
+func (c *Client) signalClosed() {
+	c.closeOnce.Do(func() { close(c.closeDone) })
 }
 
 // IsClosed returns true if Close() has finished.
@@ -603,40 +612,44 @@ func (c *Client) SetWriteDeadline(t time.Time) error {
 // Close immediately tears down the connection.
 // Future operations on non-buffered data will return io.EOF
 func (c *Client) Close() error {
-	c.closeWg.Add(1)
-	for !c.state.CompareAndSwap(clientStateOpen, clientStateClosing) {
-		cur := c.state.Load()
-		switch cur {
+	for {
+		switch c.state.Load() {
 		case clientStateCreated:
+			// Never opened; nothing to tear down.
 			if c.state.CompareAndSwap(clientStateCreated, clientStateClosed) {
-				c.closeWg.Done()
+				c.signalClosed()
 				return nil
 			}
+			// Lost the race; re-evaluate the state.
 		case clientStateHandshaking:
+			// Wait for the in-progress handshake to resolve, then re-evaluate.
 			c.handshakeWg.Wait()
+		case clientStateOpen:
+			if !c.state.CompareAndSwap(clientStateOpen, clientStateClosing) {
+				// Lost the race; re-evaluate the state.
+				continue
+			}
+			// We won the race to tear down the connection.
+			// TODO(dadrian)[2024-04-07]: Document why this is correct, or fix it.
+			c.underlyingConn.SetReadDeadline(time.Now())
+			c.wg.Wait()
+			c.state.Store(clientStateClosed)
+			c.ss.handle.Close()
+			c.underlyingConn.Close()
+			c.signalClosed()
+			return nil
 		case clientStateClosing:
-			c.closeWg.Done()
-			c.closeWg.Wait()
+			// Another goroutine is tearing down the connection. Block until it
+			// finishes so that Close does not return before the connection is
+			// safely closed.
+			<-c.closeDone
 			return nil
 		case clientStateClosed:
-			c.closeWg.Done()
 			return nil
 		case clientStateError:
-			c.closeWg.Done()
 			return c.err
 		}
 	}
-	defer c.closeWg.Done()
-	// TODO(dadrian)[2024-04-07]: Document why this is correct, or fix it.
-	c.underlyingConn.SetReadDeadline(time.Now())
-
-	c.wg.Wait()
-
-	c.state.Store(clientStateClosed)
-	c.ss.handle.Close()
-	c.underlyingConn.Close()
-
-	return nil
 }
 
 // NewClient returns a Client configured as specified, using the underlying UDP
@@ -646,6 +659,7 @@ func NewClient(conn UDPLike, server *net.UDPAddr, config ClientConfig) *Client {
 		underlyingConn: conn,
 		dialAddr:       server,
 		config:         config,
+		closeDone:      make(chan struct{}),
 	}
 	return c
 }

--- a/transport/concurrency_test.go
+++ b/transport/concurrency_test.go
@@ -1,8 +1,13 @@
 package transport
 
 import (
+	"errors"
 	"fmt"
+	"io"
+	"math/rand"
 	"net"
+	"os"
+	"sync"
 	"testing"
 	"time"
 
@@ -110,105 +115,540 @@ func TestConcurrentReadWrite(t *testing.T) {
 	}
 }
 
-// TestDeadlineInteractionUnderConcurrency ensures that deadlines can be set concurrently
-// without affecting pending I/O calls.
-//
-// Steps:
-// 1. Launch read and write operations that block indefinitely (e.g., waiting for data).
-// 2. Concurrently call SetDeadline, SetReadDeadline, and SetWriteDeadline multiple times.
-// 3. Observe that existing blocked calls eventually return errors only due to deadline expiration.
-//
-// Expected: Deadlines trigger appropriate timeout errors; setting deadlines does not leak
-// goroutines or prevent I/O from returning.
+// newConnPair sets up a Server, a Client, and the server-side Handle for a
+// single connection that has completed its handshake. The caller is responsible
+// for closing the returned Server (which tears down the Handle) and Client.
+func newConnPair(t *testing.T) (*Server, *Client, *Handle) {
+	t.Helper()
+	pc, err := net.ListenPacket("udp", "localhost:0")
+	assert.NilError(t, err)
+	serverCfg, verifyCfg := newTestServerConfig(t)
+	srv, err := NewServer(pc.(*net.UDPConn), *serverCfg)
+	assert.NilError(t, err)
+	go srv.Serve()
+
+	kp, leaf := newClientAuth(t)
+	clientCfg := ClientConfig{Verify: *verifyCfg, Exchanger: kp, Leaf: leaf}
+	cli, err := Dial("udp", srv.Addr().String(), clientCfg)
+	assert.NilError(t, err)
+	assert.NilError(t, cli.Handshake())
+
+	h, err := srv.AcceptTimeout(2 * time.Second)
+	assert.NilError(t, err)
+	return srv, cli, h
+}
+
+// waitForReceived blocks until the SessionState has received (and decrypted) a
+// packet with the given counter, indicating that all packets up to and
+// including highestCount have been delivered to the local receive queue. It
+// fails the test if that does not happen within a couple of seconds.
+func waitForReceived(t *testing.T, ss *SessionState, highestCount uint64) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		ss.m.Lock()
+		// Check returns false once the counter has been marked as seen.
+		seen := !ss.window.Check(highestCount)
+		ss.m.Unlock()
+		if seen {
+			return
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("timed out waiting for messages to arrive")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+}
+
+// TestDeadlineInteractionUnderConcurrency ensures that deadlines can be set
+// concurrently without corrupting deadline state, and that a read blocked with
+// no data returns a timeout error once its deadline is exceeded.
 func TestDeadlineInteractionUnderConcurrency(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	defer goleak.VerifyNone(t)
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	srv, cli, h := newConnPair(t)
+	defer srv.Close()
+	defer cli.Close()
+	_ = h
+
+	// Invariant: a read that blocks with no data available returns a timeout
+	// error wrapping os.ErrDeadlineExceeded once the read deadline passes.
+	t.Run("blocked read times out", func(t *testing.T) {
+		assert.NilError(t, cli.SetReadDeadline(time.Now().Add(50*time.Millisecond)))
+		buf := make([]byte, 32)
+		_, err := cli.ReadMsg(buf)
+		assert.Assert(t, errors.Is(err, os.ErrDeadlineExceeded), "expected deadline error, got %v", err)
+		// Unexpire the deadline so later operations aren't immediately timed out.
+		assert.NilError(t, cli.SetReadDeadline(time.Time{}))
+	})
+
+	// Invariant: SetDeadline, SetReadDeadline, and SetWriteDeadline may be called
+	// from many goroutines simultaneously without data races, panics, or
+	// deadlocks, and the connection remains usable afterwards.
+	t.Run("concurrent deadline setters are safe", func(t *testing.T) {
+		var wg sync.WaitGroup
+		stop := make(chan struct{})
+		for i := 0; i < 16; i++ {
+			wg.Add(1)
+			go func(seed int) {
+				defer wg.Done()
+				d := time.Duration(seed) * time.Millisecond
+				for {
+					select {
+					case <-stop:
+						return
+					default:
+					}
+					cli.SetDeadline(time.Now().Add(d))
+					cli.SetReadDeadline(time.Time{})
+					cli.SetWriteDeadline(time.Now().Add(d))
+				}
+			}(i)
+		}
+		time.Sleep(200 * time.Millisecond)
+		close(stop)
+		wg.Wait()
+
+		// The connection should still be usable: clearing deadlines succeeds and a
+		// message written by the peer is still readable.
+		assert.NilError(t, cli.SetDeadline(time.Time{}))
+		assert.NilError(t, h.WriteMsg([]byte("still alive")))
+		buf := make([]byte, 32)
+		assert.NilError(t, cli.SetReadDeadline(time.Now().Add(2*time.Second)))
+		n, err := cli.ReadMsg(buf)
+		assert.NilError(t, err)
+		assert.Equal(t, "still alive", string(buf[:n]))
+	})
 }
 
-// TestCloseUnblocksInFlightOperations verifies that calling Close on a connection
-// unblocks any in-flight ReadMsg, Read, WriteMsg, or Write calls.
+// TestCloseUnblocksInFlightOperations verifies that calling Close on a
+// connection promptly unblocks any in-flight ReadMsg/Read call with io.EOF.
 //
-// Steps:
-// 1. Start a goroutine blocking on ReadMsg (or Read).
-// 2. Start a goroutine blocking on WriteMsg (or Write) by providing no remote peer.
-// 3. Invoke Close from the main goroutine.
-// 4. Wait for blocked operations to return.
-//
-// Expected: All blocked calls return promptly with an error indicating the connection is closed.
+// Note: Write/WriteMsg do not block in this transport (packets are handed to the
+// underlying socket immediately), so there is no in-flight write to unblock.
 func TestCloseUnblocksInFlightOperations(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	t.Run("client", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		srv, cli, h := newConnPair(t)
+		defer srv.Close()
+		_ = h
+
+		readReturned := make(chan error, 1)
+		go func() {
+			_, err := cli.ReadMsg(make([]byte, 32))
+			readReturned <- err
+		}()
+		// Give the read a chance to reach its blocking state.
+		time.Sleep(100 * time.Millisecond)
+
+		start := time.Now()
+		assert.NilError(t, cli.Close())
+		select {
+		case err := <-readReturned:
+			assert.Equal(t, io.EOF, err)
+			assert.Assert(t, time.Since(start) < time.Second, "Close was slow to unblock read")
+		case <-time.After(2 * time.Second):
+			t.Fatal("Close did not unblock pending read")
+		}
+	})
+
+	t.Run("handle", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		srv, cli, h := newConnPair(t)
+		defer srv.Close()
+		defer cli.Close()
+
+		readReturned := make(chan error, 1)
+		go func() {
+			_, err := h.ReadMsg(make([]byte, 32))
+			readReturned <- err
+		}()
+		time.Sleep(100 * time.Millisecond)
+
+		start := time.Now()
+		assert.NilError(t, h.Close())
+		select {
+		case err := <-readReturned:
+			assert.Equal(t, io.EOF, err)
+			assert.Assert(t, time.Since(start) < time.Second, "Close was slow to unblock read")
+		case <-time.After(2 * time.Second):
+			t.Fatal("Close did not unblock pending read on Handle")
+		}
+	})
 }
 
-// TestBufferedDataReturnedAfterClose confirms that ReadMsg/Read can return buffered data
-// even after Close is called.
-//
-// Steps:
-// 1. Have the peer send a few messages and ensure they are queued locally.
-// 2. Call Close on the local connection.
-// 3. Consume queued messages with ReadMsg/Read until empty.
-// 4. Verify subsequent reads return io.EOF or an appropriate closed error.
-//
-// Expected: Buffered messages are delivered; after exhaustion, reads return EOF.
+// TestBufferedDataReturnedAfterClose confirms that ReadMsg can return data that
+// was queued locally before Close was called, and that reads return io.EOF only
+// once the buffered data is exhausted.
 func TestBufferedDataReturnedAfterClose(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	t.Run("client reads buffered data", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		srv, cli, h := newConnPair(t)
+		defer srv.Close()
+
+		msgs := []string{"alpha", "bravo", "charlie"}
+		for _, m := range msgs {
+			assert.NilError(t, h.WriteMsg([]byte(m)))
+		}
+		// Ensure all messages have been received by the client before closing.
+		waitForReceived(t, cli.ss, uint64(len(msgs)-1))
+
+		assert.NilError(t, cli.Close())
+
+		buf := make([]byte, 64)
+		for _, want := range msgs {
+			n, err := cli.ReadMsg(buf)
+			assert.NilError(t, err)
+			assert.Equal(t, want, string(buf[:n]))
+		}
+		_, err := cli.ReadMsg(buf)
+		assert.Equal(t, io.EOF, err)
+	})
+
+	t.Run("handle reads buffered data", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		srv, cli, h := newConnPair(t)
+		defer srv.Close()
+		defer cli.Close()
+
+		msgs := []string{"one", "two", "three"}
+		for _, m := range msgs {
+			assert.NilError(t, cli.WriteMsg([]byte(m)))
+		}
+		waitForReceived(t, h.ss, uint64(len(msgs)-1))
+
+		assert.NilError(t, h.Close())
+
+		buf := make([]byte, 64)
+		for _, want := range msgs {
+			n, err := h.ReadMsg(buf)
+			assert.NilError(t, err)
+			assert.Equal(t, want, string(buf[:n]))
+		}
+		_, err := h.ReadMsg(buf)
+		assert.Equal(t, io.EOF, err)
+	})
 }
 
 // TestWriteFailsAfterClose ensures that any WriteMsg/Write performed after Close
-// immediately returns an error.
-//
-// Steps:
-// 1. Call Close on the connection.
-// 2. Attempt to send new messages.
-//
-// Expected: Writes return a "use of closed network connection" or equivalent error.
+// immediately returns io.EOF, for both the Client and the server-side Handle.
 func TestWriteFailsAfterClose(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	t.Run("client", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		srv, cli, h := newConnPair(t)
+		defer srv.Close()
+		_ = h
+
+		assert.NilError(t, cli.Close())
+
+		assert.Equal(t, io.EOF, cli.WriteMsg([]byte("x")))
+		n, err := cli.Write([]byte("y"))
+		assert.Equal(t, 0, n)
+		assert.Equal(t, io.EOF, err)
+	})
+
+	t.Run("handle", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		srv, cli, h := newConnPair(t)
+		defer srv.Close()
+		defer cli.Close()
+
+		assert.NilError(t, h.Close())
+
+		// Before the closeLocked fix, the Handle never transitioned to the closed
+		// state and these writes silently succeeded on the wire.
+		assert.Assert(t, h.IsClosed())
+		assert.Equal(t, io.EOF, h.WriteMsg([]byte("x")))
+		n, err := h.Write([]byte("y"))
+		assert.Equal(t, 0, n)
+		assert.Equal(t, io.EOF, err)
+	})
 }
 
-// TestIdempotentClose validates that multiple calls to Close do not cause panics or
-// additional errors.
-//
-// Steps:
-// 1. Call Close on the connection once.
-// 2. Call Close again.
-//
-// Expected: Subsequent Close calls return a consistent error or nil and do not panic.
+// TestIdempotentClose validates that multiple calls to Close, whether sequential
+// or concurrent, do not panic and return consistently.
 func TestIdempotentClose(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	t.Run("client sequential", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		srv, cli, h := newConnPair(t)
+		defer srv.Close()
+		_ = h
+		for i := 0; i < 3; i++ {
+			assert.NilError(t, cli.Close())
+		}
+	})
+
+	t.Run("client concurrent", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		srv, cli, h := newConnPair(t)
+		defer srv.Close()
+		_ = h
+		var wg sync.WaitGroup
+		errs := make([]error, 20)
+		for i := range errs {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				errs[i] = cli.Close()
+			}(i)
+		}
+		wg.Wait()
+		for _, err := range errs {
+			assert.NilError(t, err)
+		}
+		assert.Equal(t, cli.state.Load(), clientStateClosed)
+	})
+
+	t.Run("handle concurrent", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		srv, cli, h := newConnPair(t)
+		defer srv.Close()
+		defer cli.Close()
+		var wg sync.WaitGroup
+		errs := make([]error, 20)
+		for i := range errs {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				errs[i] = h.Close()
+			}(i)
+		}
+		wg.Wait()
+		for _, err := range errs {
+			assert.NilError(t, err)
+		}
+		assert.Assert(t, h.IsClosed())
+	})
+
+	// Concurrent Server.Close calls must not panic (the previous WaitGroup-based
+	// barrier could panic with "WaitGroup is reused before previous Wait has
+	// returned") and every caller must return nil.
+	t.Run("server concurrent", func(t *testing.T) {
+		defer goleak.VerifyNone(t)
+		srv, cli, h := newConnPair(t)
+		defer cli.Close()
+		_ = h
+		var wg sync.WaitGroup
+		errs := make([]error, 20)
+		for i := range errs {
+			wg.Add(1)
+			go func(i int) {
+				defer wg.Done()
+				errs[i] = srv.Close()
+			}(i)
+		}
+		wg.Wait()
+		for _, err := range errs {
+			assert.NilError(t, err)
+		}
+	})
 }
 
-// TestPeerInitiatedClose tests behavior when the remote endpoint closes the connection.
-//
-// Steps:
-// 1. After handshake, have the peer call Close.
-// 2. Perform ReadMsg/Read and WriteMsg/Write on the other side.
-//
-// Expected: Reads return EOF or closed error; writes return closed connection error.
+// TestPeerInitiatedClose tests that when the remote endpoint sends a Close
+// control message, the receiving side transitions into the closed state and
+// subsequent writes fail with io.EOF.
 func TestPeerInitiatedClose(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	defer goleak.VerifyNone(t)
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	srv, cli, h := newConnPair(t)
+	defer srv.Close()
+	defer cli.Close()
+
+	// The server sends a Close control message to the client.
+	h.ss.m.Lock()
+	err := h.writeControlLocked(ControlMessageClose)
+	h.ss.m.Unlock()
+	assert.NilError(t, err)
+
+	// The client's listen loop should process the control message and mark the
+	// session closed.
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		cli.ss.m.Lock()
+		st := cli.ss.handleState
+		cli.ss.m.Unlock()
+		if st == closed {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("client did not observe peer-initiated close")
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+
+	// Writes after the peer-initiated close fail.
+	assert.Equal(t, io.EOF, cli.WriteMsg([]byte("after peer close")))
 }
 
-// TestRaceBetweenCloseAndDeadlineOrIO stresses race conditions by invoking Close,
-// deadline changes, and I/O in rapid succession.
-//
-// Steps:
-//  1. Spawn multiple goroutines each randomly choosing to ReadMsg, WriteMsg,
-//     set deadlines, or Close.
-//  2. Run for a short duration under the race detector.
-//
-// Expected: No data races, deadlocks, or unexpected panics.
+// TestRaceBetweenCloseAndDeadlineOrIO stresses race conditions by invoking
+// Close, deadline changes, and I/O in rapid succession on a single connection.
+// Its correctness check is the absence of data races (under -race), panics, and
+// deadlocks: the test fails if the workers do not all return.
 func TestRaceBetweenCloseAndDeadlineOrIO(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	defer goleak.VerifyNone(t)
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	srv, cli, h := newConnPair(t)
+	defer srv.Close()
+	defer h.Close()
+
+	const workers = 16
+	stopAt := time.Now().Add(300 * time.Millisecond)
+	var wg sync.WaitGroup
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func(seed int) {
+			defer wg.Done()
+			r := rand.New(rand.NewSource(int64(seed)))
+			buf := make([]byte, 64)
+			for time.Now().Before(stopAt) {
+				switch r.Intn(6) {
+				case 0:
+					cli.SetReadDeadline(time.Now().Add(20 * time.Millisecond))
+					cli.ReadMsg(buf)
+				case 1:
+					cli.WriteMsg([]byte("data"))
+				case 2:
+					cli.SetDeadline(time.Now().Add(time.Duration(r.Intn(30)) * time.Millisecond))
+				case 3:
+					h.WriteMsg([]byte("echo"))
+				case 4:
+					h.SetReadDeadline(time.Now().Add(20 * time.Millisecond))
+					h.ReadMsg(buf)
+				case 5:
+					// Only one worker ever closes, roughly halfway through.
+					if seed == workers-1 && time.Now().After(stopAt.Add(-150*time.Millisecond)) {
+						cli.Close()
+					}
+				}
+			}
+		}(i)
+	}
+
+	done := make(chan struct{})
+	go func() { wg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(10 * time.Second):
+		t.Fatal("possible deadlock: workers did not finish")
+	}
+
+	// Ensure the client is fully closed for goleak.
+	cli.Close()
 }
 
-// TestStressHighConcurrency subjects the connection to high-volume, concurrent reads,
-// writes, deadlines, and closes to uncover subtle races.
-//
-// Steps:
-//  1. Use a large number of goroutines performing random operations (ReadMsg,
-//     WriteMsg, SetDeadline, Close).
-//  2. Run under go test -race with sufficient iterations.
-//
-// Expected: Stability under load with correct semantics.
+// TestStressHighConcurrency subjects the server to many concurrent connections
+// that each perform concurrent reads, writes, deadline changes, and a close.
+// Like the race test, it passes if it completes without deadlock, panic, or
+// (under -race) data races.
 func TestStressHighConcurrency(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	defer goleak.VerifyNone(t)
+	logrus.SetLevel(logrus.ErrorLevel)
+
+	pc, err := net.ListenPacket("udp", "localhost:0")
+	assert.NilError(t, err)
+	serverCfg, verifyCfg := newTestServerConfig(t)
+	srv, err := NewServer(pc.(*net.UDPConn), *serverCfg)
+	assert.NilError(t, err)
+	defer srv.Close()
+	go srv.Serve()
+
+	// Accept connections and echo everything back until the server is closed.
+	var serverWg sync.WaitGroup
+	serverWg.Add(1)
+	go func() {
+		defer serverWg.Done()
+		for {
+			h, err := srv.AcceptTimeout(500 * time.Millisecond)
+			if err == io.EOF {
+				return // server closed
+			}
+			if err != nil {
+				continue // timeout, keep waiting
+			}
+			serverWg.Add(1)
+			go func(h *Handle) {
+				defer serverWg.Done()
+				buf := make([]byte, 2048)
+				for {
+					n, err := h.ReadMsg(buf)
+					if err != nil {
+						return
+					}
+					if err := h.WriteMsg(buf[:n]); err != nil {
+						return
+					}
+				}
+			}(h)
+		}
+	}()
+
+	const clients = 12
+	var clientWg sync.WaitGroup
+	for i := 0; i < clients; i++ {
+		clientWg.Add(1)
+		go func(seed int) {
+			defer clientWg.Done()
+			kp, leaf := newClientAuth(t)
+			clientCfg := ClientConfig{Verify: *verifyCfg, Exchanger: kp, Leaf: leaf}
+			cli, err := Dial("udp", srv.Addr().String(), clientCfg)
+			if err != nil {
+				return
+			}
+			defer cli.Close()
+
+			stopAt := time.Now().Add(200 * time.Millisecond)
+			var ops sync.WaitGroup
+			// Writer.
+			ops.Add(1)
+			go func() {
+				defer ops.Done()
+				for time.Now().Before(stopAt) {
+					cli.WriteMsg([]byte(fmt.Sprintf("c%d", seed)))
+				}
+			}()
+			// Reader.
+			ops.Add(1)
+			go func() {
+				defer ops.Done()
+				buf := make([]byte, 64)
+				for time.Now().Before(stopAt) {
+					cli.SetReadDeadline(time.Now().Add(20 * time.Millisecond))
+					cli.ReadMsg(buf)
+				}
+			}()
+			// Deadline churn.
+			ops.Add(1)
+			go func() {
+				defer ops.Done()
+				for time.Now().Before(stopAt) {
+					cli.SetDeadline(time.Now().Add(15 * time.Millisecond))
+				}
+			}()
+			ops.Wait()
+		}(i)
+	}
+
+	done := make(chan struct{})
+	go func() { clientWg.Wait(); close(done) }()
+	select {
+	case <-done:
+	case <-time.After(20 * time.Second):
+		t.Fatal("possible deadlock: clients did not finish")
+	}
+
+	// Shut down the server and wait for the accept/echo goroutines to exit so
+	// goleak sees a clean slate.
+	srv.Close()
+	serverWg.Wait()
 }

--- a/transport/server.go
+++ b/transport/server.go
@@ -50,8 +50,18 @@ type Server struct {
 	cookieLock       sync.Mutex
 	stopCookieRotate chan struct{}
 
-	wg        sync.WaitGroup
-	closeWait sync.WaitGroup
+	wg sync.WaitGroup
+
+	// closeDone is closed exactly once (guarded by closeOnce) when the server
+	// has been fully shut down. Concurrent callers of Close that lose the race
+	// to perform the shutdown block on it so that Close never returns before the
+	// server is safely closed.
+	closeOnce sync.Once
+	closeDone chan struct{}
+}
+
+func (s *Server) signalClosed() {
+	s.closeOnce.Do(func() { close(s.closeDone) })
 }
 
 func (s *Server) setHandshakeState(remoteAddr *net.UDPAddr, hs *HandshakeState) bool {
@@ -734,62 +744,69 @@ func (s *Server) Addr() net.Addr {
 
 // Close stops the server, causing Serve() to return.
 func (s *Server) Close() (err error) {
-	s.closeWait.Add(1)
-	for !s.state.CompareAndSwap(uint32(serverStateServing), uint32(serverStateClosing)) {
-		cur := serverState(s.state.Load())
-		switch cur {
+	for {
+		switch serverState(s.state.Load()) {
 		case serverStateReady:
+			// Never started serving; nothing to tear down.
 			if s.state.CompareAndSwap(uint32(serverStateReady), uint32(serverStateClosed)) {
-				s.closeWait.Done()
+				s.signalClosed()
 				return nil
 			}
+			// Lost the race; re-evaluate the state.
+		case serverStateServing:
+			if !s.state.CompareAndSwap(uint32(serverStateServing), uint32(serverStateClosing)) {
+				// Lost the race; re-evaluate the state.
+				continue
+			}
+			// We won the race to shut the server down.
+
+			// Stop reading packets
+			s.udpConn.SetReadDeadline(time.Now())
+			// Stop rotating cookies inside readPacket
+			close(s.stopCookieRotate)
+			// Wait for read packet to finish
+			s.wg.Wait()
+
+			// Close the channels
+			close(s.pendingConnections)
+
+			// Drain everything and close the connections
+			wg := sync.WaitGroup{}
+			func() {
+				s.m.Lock()
+				defer s.m.Unlock()
+				for h := range s.pendingConnections {
+					wg.Add(1)
+					go func(h *Handle) {
+						defer wg.Done()
+						h.Close()
+					}(h)
+				}
+				for _, ss := range s.sessions {
+					wg.Add(1)
+					go func(ss *SessionState) {
+						defer wg.Done()
+						if ss.handle != nil {
+							ss.handle.Close()
+						}
+						s.stopTrackingSession(ss.sessionID)
+					}(ss)
+				}
+			}()
+			wg.Wait()
+			s.udpConn.Close()
+			s.signalClosed()
+			return nil
 		case serverStateClosing:
-			s.closeWait.Done()
-			s.closeWait.Wait()
+			// Another goroutine is shutting the server down. Block until it
+			// finishes so that Close does not return before the server is safely
+			// closed.
+			<-s.closeDone
 			return nil
 		case serverStateClosed:
-			s.closeWait.Done()
 			return nil
 		}
 	}
-	defer s.closeWait.Done()
-
-	// Stop reading packets
-	s.udpConn.SetReadDeadline(time.Now())
-	// Stop rotating cookies inside readPacket
-	close(s.stopCookieRotate)
-	// Wait for read packet to finish
-	s.wg.Wait()
-
-	// Close the channels
-	close(s.pendingConnections)
-
-	// Drain everything and close the connections
-	wg := sync.WaitGroup{}
-	func() {
-		s.m.Lock()
-		defer s.m.Unlock()
-		for h := range s.pendingConnections {
-			wg.Add(1)
-			go func(h *Handle) {
-				defer wg.Done()
-				h.Close()
-			}(h)
-		}
-		for _, ss := range s.sessions {
-			wg.Add(1)
-			go func(ss *SessionState) {
-				defer wg.Done()
-				if ss.handle != nil {
-					ss.handle.Close()
-				}
-				s.stopTrackingSession(ss.sessionID)
-			}(ss)
-		}
-	}()
-	wg.Wait()
-	s.udpConn.Close()
-	return nil
 }
 
 func (s *Server) init() error {
@@ -860,6 +877,7 @@ func NewServer(conn UDPLike, config ServerConfig) (*Server, error) {
 		udpConn:          conn,
 		config:           config,
 		stopCookieRotate: make(chan struct{}),
+		closeDone:        make(chan struct{}),
 	}
 	err := s.init()
 	return &s, err

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -243,7 +243,13 @@ func (ss *SessionState) closeLocked() (err error) {
 	if ss.handleState == closed {
 		return nil
 	}
-	// TODO(dadrian)[2023-09-09]: Actually close. This is hard because sometimes
+	// Transition into the closed state. Once closed, writes via Handle.send
+	// return io.EOF and Handle.IsClosed reports true. The receive queue is
+	// drained separately (see Handle.Close) so that buffered data can still be
+	// read after a close.
+	//
+	// TODO(dadrian)[2023-09-09]: Notify the peer. This is hard because sometimes
 	// the Server knows we're closing, and sometimes only the Handle knows.
+	ss.handleState = closed
 	return nil
 }


### PR DESCRIPTION
## Summary

An audit of the `transport/` concurrency model surfaced three real bugs. All are fixed and covered by tests (the eight previously-stubbed invariant tests in `concurrency_test.go` are now implemented, plus a concurrent `Server.Close` case).

## Bugs fixed

1. **`Close()` panicked under concurrent callers.** Both `Client.Close` and `Server.Close` used a `sync.WaitGroup` as a "late-closer barrier" (`Add`/`Done`/`Wait`). When the counter reached zero and another `Close` called `Add(1)` before a prior `Wait()` returned, Go panics: `sync: WaitGroup is reused before previous Wait has returned`. `TestIdempotentClose` reproduces it under `-race`. Replaced with a `sync.Once` + `closeDone` channel broadcast barrier — losers block on a channel closed exactly once when teardown completes, with no reuse hazard.

2. **`SessionState.closeLocked()` was a no-op** that never set `handleState = closed`. As a result the server-side `Handle`'s `IsClosed()` always returned `false` and `Write`/`WriteMsg` silently succeeded after `Close()` (packets went out on the wire), violating the documented invariant that all writes fail after a close. Verified `TestWriteFailsAfterClose/handle` fails without this fix.

3. With (2) fixed, receiving a `Close` control message now actually closes the session (peer-initiated close), covered by `TestPeerInitiatedClose`.

## Tests added

Implemented every stub in `concurrency_test.go`: deadline interaction under concurrency, close-unblocks-in-flight-reads (client + handle), buffered-data-returned-after-close, write-fails-after-close, idempotent/concurrent close (client + handle + server), peer-initiated close, and the race/stress tests. All pass under `-race` across repeated runs (`-count=3` full suite, `-count=5` on the nondeterministic ones).

## Out-of-scope note

`common.DeadlineChan.Send` holds its mutex across a blocking channel op while `Close` needs that same mutex — a latent deadlock. It is **not reachable from `transport/`** (transport uses raw non-blocking channel sends and only `Recv`, which deliberately does not hold the mutex), but it is used by `tubes/unreliable.go` and is worth a follow-up there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)