### PR TITLE
transport: fix concurrency lifecycle and close races

### DIFF
--- a/makefile
+++ b/makefile
@@ -11,6 +11,10 @@ ifeq (, $(shell command -v "GOLANG_CHECKLOCKS"))
 	GOLANG_CHECKLOCKS_ERR = $(error install checklocks eith e.g. go install gvisor.dev/gvisor/tools/checklocks/cmd/checklocks@go)
 endif
 
+CONCURRENCY_TEST_COUNT ?= 10
+CONCURRENCY_TEST_PACKAGES := ./transport ./tubes ./hoptests
+CONCURRENCY_TEST_PROCS := 1 2 4
+
 .PHONY: vet
 vet: ## run go vet. Currently, this only checks for deadlocks
 vet:
@@ -41,6 +45,13 @@ debug:
 test: ## test. To run with trace logging, add "-tags debug" to the arguments
 test:
 	go test -race ./... -timeout 4m
+
+.PHONY: test-concurrency
+test-concurrency: ## stress concurrency-heavy packages under varied scheduler widths
+	@for procs in $(CONCURRENCY_TEST_PROCS); do \
+		echo "concurrency tests: GOMAXPROCS=$$procs count=$(CONCURRENCY_TEST_COUNT)"; \
+		GOMAXPROCS=$$procs go test -race -shuffle=on -count=$(CONCURRENCY_TEST_COUNT) $(CONCURRENCY_TEST_PACKAGES) || exit 1; \
+	done
 
 .PHONY: cred-gen
 cred-gen: ## generates credentials for container tests

--- a/transport/client.go
+++ b/transport/client.go
@@ -77,6 +77,7 @@ func (c *Client) Handshake() error {
 
 			err := c.clientHandshakeLocked()
 			if err != nil {
+				// Store the error before publishing clientStateError so concurrent callers cannot observe an uninitialized result.
 				c.err = err
 				if c.state.CompareAndSwap(clientStateHandshaking, clientStateError) {
 					c.hs = nil
@@ -85,6 +86,7 @@ func (c *Client) Handshake() error {
 			}
 			close(c.handshakeDone)
 
+			// Recheck after completion because Close may have changed the state while the handshake was running.
 			state := c.state.Load()
 			if state == clientStateClosing || state == clientStateClosed {
 				return io.EOF

--- a/transport/client.go
+++ b/transport/client.go
@@ -43,6 +43,8 @@ type Client struct {
 	wg    sync.WaitGroup
 	state atomic.Uint32
 
+	// handshakeDone closes after the elected Handshake caller stores its result.
+	// Closing it publishes err, hs, and ss to all concurrent waiters.
 	handshakeDone chan struct{}
 
 	underlyingConn UDPLike
@@ -55,6 +57,8 @@ type Client struct {
 
 	config ClientConfig
 
+	// closeDone closes after the elected Close caller stops all producers and
+	// stores closeErr. Later Close calls wait for that publication.
 	closeDone chan struct{}
 	closeErr  error
 }
@@ -508,7 +512,8 @@ func (c *Client) handleSessionMessage(addr *net.UDPAddr, msg []byte) error {
 	return nil
 }
 
-// Write implements net.Conn.
+// Write implements net.Conn. A successful return means the configured
+// underlying transport accepted each packet, not that the peer received it.
 func (c *Client) Write(b []byte) (int, error) {
 	if err := c.Handshake(); err != nil {
 		return 0, err
@@ -516,7 +521,8 @@ func (c *Client) Write(b []byte) (int, error) {
 	return c.ss.handle.Write(b)
 }
 
-// WriteMsg implements MsgConn. It send a single frame.
+// WriteMsg implements MsgConn. A successful return means the configured
+// underlying transport accepted the message, not that the peer received it.
 func (c *Client) WriteMsg(b []byte) error {
 	if err := c.Handshake(); err != nil {
 		return err
@@ -602,8 +608,8 @@ func (c *Client) SetWriteDeadline(t time.Time) error {
 	return nil
 }
 
-// Close immediately tears down the connection.
-// Future operations on non-buffered data will return io.EOF
+// Close tears down the underlying connection and waits for all Client-owned
+// workers. Future operations on non-buffered data return io.EOF.
 func (c *Client) Close() error {
 	var previous uint32
 	for {

--- a/transport/client.go
+++ b/transport/client.go
@@ -43,20 +43,20 @@ type Client struct {
 	wg    sync.WaitGroup
 	state atomic.Uint32
 
-	handshakeWg sync.WaitGroup
+	handshakeDone chan struct{}
 
 	underlyingConn UDPLike
 	dialAddr       *net.UDPAddr
 
-	err          error
-	handshakeErr error
-	hs           *HandshakeState
+	err error
+	hs  *HandshakeState
 
 	ss *SessionState
 
 	config ClientConfig
 
-	closeWg sync.WaitGroup
+	closeDone chan struct{}
+	closeErr  error
 }
 
 // IsClosed returns true if Close() has finished.
@@ -68,58 +68,38 @@ func (c *Client) IsClosed() bool {
 // must already be open. It is an error to call Handshake on a connection that
 // has already performed the portal handshake.
 func (c *Client) Handshake() error {
-	state := c.state.Load()
-	switch state {
-	case clientStateHandshaking:
-		// Wait for the handshake to finish, then return the cached error.
-		c.handshakeWg.Wait()
-		return c.handshakeErr
-	case clientStateOpen:
-		// If the client is open, it can't have had a handshake error.
-		return nil
-	case clientStateError:
-		return c.err
-	case clientStateClosing, clientStateClosed:
-		if c.hs != nil {
-			return nil
-		}
-		return io.EOF
-	}
-
-	// Only add to the semaphor if the first check indicates we might need to handshake.
-	c.handshakeWg.Add(1)
-	for !c.state.CompareAndSwap(clientStateCreated, clientStateHandshaking) {
-		state := c.state.Load()
-		switch state {
+	for {
+		switch c.state.Load() {
 		case clientStateCreated:
-			// Do nothing, try again
+			if !c.state.CompareAndSwap(clientStateCreated, clientStateHandshaking) {
+				continue
+			}
+
+			err := c.clientHandshakeLocked()
+			if err != nil {
+				c.err = err
+				if c.state.CompareAndSwap(clientStateHandshaking, clientStateError) {
+					c.hs = nil
+					c.ss = nil
+				}
+			}
+			close(c.handshakeDone)
+
+			state := c.state.Load()
+			if state == clientStateClosing || state == clientStateClosed {
+				return io.EOF
+			}
+			return err
 		case clientStateHandshaking:
-			c.handshakeWg.Done()
-			c.handshakeWg.Wait()
-			return c.handshakeErr
+			<-c.handshakeDone
 		case clientStateOpen:
-			c.handshakeWg.Done()
 			return nil
 		case clientStateError:
 			return c.err
 		case clientStateClosing, clientStateClosed:
-			c.handshakeWg.Done()
-			if c.hs != nil {
-				return nil
-			}
 			return io.EOF
 		}
 	}
-	defer c.handshakeWg.Done()
-	logrus.Info("Handshake not complete. Completing handshake...")
-	c.handshakeErr = c.clientHandshakeLocked()
-	if c.handshakeErr != nil {
-		c.hs = nil
-		c.ss = nil
-		c.err = c.handshakeErr
-		c.state.Store(clientStateError)
-	}
-	return c.handshakeErr
 }
 
 func (c *Client) prepareCertificates() (leaf, intermediate []byte, err error) {
@@ -154,7 +134,7 @@ func (c *Client) setHSDeadline() {
 }
 
 func (c *Client) clientHandshakeLocked() error {
-	c.state.Store(clientStateHandshaking)
+	logrus.Info("Handshake not complete. Completing handshake...")
 	c.hs = new(HandshakeState)
 	c.hs.duplex.InitializeEmpty()
 
@@ -226,8 +206,11 @@ func (c *Client) clientHandshakeLocked() error {
 	// we should have a DialContext.
 	c.underlyingConn.SetReadDeadline(time.Time{})
 	c.ss.handle = newHandleForSession(c.underlyingConn, c.ss, c.config.Leaf, c.config.maxBufferedPackets())
-	c.state.Store(clientStateOpen)
 	c.wg.Add(1)
+	if !c.state.CompareAndSwap(clientStateHandshaking, clientStateOpen) {
+		c.wg.Done()
+		return io.EOF
+	}
 	go c.listen()
 
 	return nil
@@ -458,7 +441,6 @@ func (c *Client) beginPQHiddenHandshake(buf []byte) error {
 func (c *Client) listen() {
 	defer c.wg.Done()
 	ciphertext := make([]byte, 65535)
-	c.handshakeWg.Wait()
 	for c.state.Load() == clientStateOpen {
 		msgLen, _, _, addr, err := c.underlyingConn.ReadMsgUDP(ciphertext, nil)
 		if err != nil {
@@ -466,6 +448,7 @@ func (c *Client) listen() {
 				continue
 			}
 			logrus.Errorf("client: error reading packet %s", err)
+			continue
 		}
 		c.handleSessionMessage(addr, ciphertext[:msgLen])
 	}
@@ -484,6 +467,9 @@ func (c *Client) handleSessionMessage(addr *net.UDPAddr, msg []byte) error {
 	defer c.ss.m.Unlock()
 	if sessionID != c.ss.sessionID {
 		return ErrUnknownSession
+	}
+	if c.ss.handleState == closed {
+		return nil
 	}
 
 	// TODO(dadrian): Can we avoid this allocation?
@@ -546,6 +532,13 @@ func (c *Client) ReadMsg(b []byte) (n int, err error) {
 		}
 	case clientStateError:
 		return 0, c.err
+	case clientStateClosing:
+		return 0, io.EOF
+	case clientStateClosed:
+		<-c.closeDone
+		if c.ss == nil || c.ss.handle == nil {
+			return 0, io.EOF
+		}
 	}
 	return c.ss.handle.ReadMsg(b)
 }
@@ -559,6 +552,13 @@ func (c *Client) Read(b []byte) (n int, err error) {
 		}
 	case clientStateError:
 		return 0, c.err
+	case clientStateClosing:
+		return 0, io.EOF
+	case clientStateClosed:
+		<-c.closeDone
+		if c.ss == nil || c.ss.handle == nil {
+			return 0, io.EOF
+		}
 	}
 	return c.ss.handle.Read(b)
 }
@@ -603,40 +603,36 @@ func (c *Client) SetWriteDeadline(t time.Time) error {
 // Close immediately tears down the connection.
 // Future operations on non-buffered data will return io.EOF
 func (c *Client) Close() error {
-	c.closeWg.Add(1)
-	for !c.state.CompareAndSwap(clientStateOpen, clientStateClosing) {
-		cur := c.state.Load()
-		switch cur {
-		case clientStateCreated:
-			if c.state.CompareAndSwap(clientStateCreated, clientStateClosed) {
-				c.closeWg.Done()
-				return nil
+	var previous uint32
+	for {
+		previous = c.state.Load()
+		switch previous {
+		case clientStateClosing, clientStateClosed:
+			<-c.closeDone
+			return c.closeErr
+		default:
+			if c.state.CompareAndSwap(previous, clientStateClosing) {
+				goto closing
 			}
-		case clientStateHandshaking:
-			c.handshakeWg.Wait()
-		case clientStateClosing:
-			c.closeWg.Done()
-			c.closeWg.Wait()
-			return nil
-		case clientStateClosed:
-			c.closeWg.Done()
-			return nil
-		case clientStateError:
-			c.closeWg.Done()
-			return c.err
 		}
 	}
-	defer c.closeWg.Done()
-	// TODO(dadrian)[2024-04-07]: Document why this is correct, or fix it.
-	c.underlyingConn.SetReadDeadline(time.Now())
 
+closing:
+	// Closing the underlying connection is what guarantees that an in-flight
+	// handshake, read, or write cannot prevent Close from completing.
+	c.closeErr = c.underlyingConn.Close()
+
+	if previous == clientStateHandshaking {
+		<-c.handshakeDone
+	}
 	c.wg.Wait()
+	if c.ss != nil && c.ss.handle != nil {
+		_ = c.ss.handle.Close()
+	}
 
 	c.state.Store(clientStateClosed)
-	c.ss.handle.Close()
-	c.underlyingConn.Close()
-
-	return nil
+	close(c.closeDone)
+	return c.closeErr
 }
 
 // NewClient returns a Client configured as specified, using the underlying UDP
@@ -646,6 +642,8 @@ func NewClient(conn UDPLike, server *net.UDPAddr, config ClientConfig) *Client {
 		underlyingConn: conn,
 		dialAddr:       server,
 		config:         config,
+		handshakeDone:  make(chan struct{}),
+		closeDone:      make(chan struct{}),
 	}
 	return c
 }

--- a/transport/concurrency_test.go
+++ b/transport/concurrency_test.go
@@ -476,15 +476,8 @@ func TestRaceBetweenCloseAndDeadlineOrIO(t *testing.T) {
 	assert.Check(t, h.IsClosed())
 }
 
-// TestStressHighConcurrency subjects the connection to high-volume, concurrent reads,
-// writes, deadlines, and closes to uncover subtle races.
-//
-// Steps:
-//  1. Use a large number of goroutines performing random operations (ReadMsg,
-//     WriteMsg, SetDeadline, Close).
-//  2. Run under go test -race with sufficient iterations.
-//
-// Expected: Stability under load with correct semantics.
+// TestStressHighConcurrency verifies that concurrent writes are serialized so
+// every successful write emits one packet with a unique counter.
 func TestStressHighConcurrency(t *testing.T) {
 	conn := newConcurrencyTestConn()
 	h := newConcurrencyTestHandle(conn, 1)
@@ -512,6 +505,8 @@ func TestStressHighConcurrency(t *testing.T) {
 	assert.NilError(t, h.Close())
 }
 
+// TestClientCloseInterruptsHandshake verifies that Close owns shutdown, closes
+// the underlying connection once, and unblocks an in-flight handshake.
 func TestClientCloseInterruptsHandshake(t *testing.T) {
 	conn := newConcurrencyTestConn()
 	_, verify := newTestServerConfig(t)
@@ -538,6 +533,8 @@ func TestClientCloseInterruptsHandshake(t *testing.T) {
 	assert.Equal(t, conn.closeN.Load(), int32(1))
 }
 
+// TestConcurrentHandshakeRunsOnce verifies that concurrent callers share one
+// handshake result and create exactly one server-side connection.
 func TestConcurrentHandshakeRunsOnce(t *testing.T) {
 	pc, err := net.ListenPacket("udp", "localhost:0")
 	assert.NilError(t, err)
@@ -581,6 +578,8 @@ func TestConcurrentHandshakeRunsOnce(t *testing.T) {
 	assert.Equal(t, err, ErrTimeout, "concurrent callers performed more than one handshake")
 }
 
+// TestConcurrentClientCloseBeforeHandshake verifies that pre-handshake Close is
+// concurrency-safe, idempotent, and closes the underlying connection once.
 func TestConcurrentClientCloseBeforeHandshake(t *testing.T) {
 	conn := newConcurrencyTestConn()
 	client := NewClient(conn, conn.RemoteAddr().(*net.UDPAddr), ClientConfig{})
@@ -602,6 +601,8 @@ func TestConcurrentClientCloseBeforeHandshake(t *testing.T) {
 	assert.Check(t, errors.Is(err, io.EOF))
 }
 
+// TestServerServeCloseRace verifies that worker registration is synchronized
+// with Close, so racing Serve and Close cannot deadlock or close twice.
 func TestServerServeCloseRace(t *testing.T) {
 	for range 100 {
 		conn := newConcurrencyTestConn()
@@ -628,6 +629,8 @@ func TestServerServeCloseRace(t *testing.T) {
 	}
 }
 
+// TestConcurrentServerCloseUnblocksAccept verifies that concurrent Close calls
+// have one owner and unblock both Serve and Accept exactly once.
 func TestConcurrentServerCloseUnblocksAccept(t *testing.T) {
 	conn := newConcurrencyTestConn()
 	config, _ := newTestServerConfig(t)

--- a/transport/concurrency_test.go
+++ b/transport/concurrency_test.go
@@ -1,8 +1,14 @@
 package transport
 
 import (
+	"encoding/binary"
+	"errors"
 	"fmt"
+	"io"
 	"net"
+	"os"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -10,6 +16,132 @@ import (
 	"go.uber.org/goleak"
 	"gotest.tools/assert"
 )
+
+type concurrencyTestConn struct {
+	closed    chan struct{}
+	closeOnce sync.Once
+	closeN    atomic.Int32
+
+	readStarted     chan struct{}
+	readStartedOnce sync.Once
+
+	blockTransport   bool
+	transportStarted chan struct{}
+	transportOnce    sync.Once
+	releaseTransport chan struct{}
+
+	packetsMu sync.Mutex
+	// +checklocks:packetsMu
+	packets [][]byte
+}
+
+func newConcurrencyTestConn() *concurrencyTestConn {
+	return &concurrencyTestConn{
+		closed:           make(chan struct{}),
+		readStarted:      make(chan struct{}),
+		transportStarted: make(chan struct{}),
+		releaseTransport: make(chan struct{}),
+	}
+}
+
+func (c *concurrencyTestConn) Read(b []byte) (int, error) {
+	n, _, _, _, err := c.ReadMsgUDP(b, nil)
+	return n, err
+}
+
+func (c *concurrencyTestConn) Write(b []byte) (int, error) {
+	n, _, err := c.WriteMsgUDP(b, nil, nil)
+	return n, err
+}
+
+func (c *concurrencyTestConn) Close() error {
+	c.closeN.Add(1)
+	c.closeOnce.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}
+
+func (c *concurrencyTestConn) LocalAddr() net.Addr {
+	return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 1}
+}
+
+func (c *concurrencyTestConn) RemoteAddr() net.Addr {
+	return &net.UDPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 2}
+}
+
+func (c *concurrencyTestConn) SetDeadline(time.Time) error      { return nil }
+func (c *concurrencyTestConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *concurrencyTestConn) SetWriteDeadline(time.Time) error { return nil }
+
+func (c *concurrencyTestConn) WriteMsgUDP(b, _ []byte, _ *net.UDPAddr) (int, int, error) {
+	if len(b) > 0 && MessageType(b[0]) == MessageTypeTransport && c.blockTransport {
+		c.transportOnce.Do(func() {
+			close(c.transportStarted)
+		})
+		select {
+		case <-c.releaseTransport:
+		case <-c.closed:
+			return 0, 0, net.ErrClosed
+		}
+	}
+
+	select {
+	case <-c.closed:
+		return 0, 0, net.ErrClosed
+	default:
+	}
+
+	c.packetsMu.Lock()
+	c.packets = append(c.packets, append([]byte(nil), b...))
+	c.packetsMu.Unlock()
+	return len(b), 0, nil
+}
+
+func (c *concurrencyTestConn) ReadMsgUDP([]byte, []byte) (int, int, int, *net.UDPAddr, error) {
+	c.readStartedOnce.Do(func() {
+		close(c.readStarted)
+	})
+	<-c.closed
+	return 0, 0, 0, nil, net.ErrClosed
+}
+
+func newConcurrencyTestHandle(conn UDPLike, bufferSize int) *Handle {
+	ss := &SessionState{
+		handleState: established,
+		remoteAddr: &net.UDPAddr{
+			IP:   net.IPv4(127, 0, 0, 1),
+			Port: 2,
+		},
+	}
+	ss.readKey = &ss.clientToServerKey
+	ss.writeKey = &ss.serverToClientKey
+	ss.handle = newHandleForSession(conn, ss, nil, bufferSize)
+	return ss.handle
+}
+
+func waitForResult[T any](t *testing.T, ch <-chan T, message string) T {
+	t.Helper()
+	select {
+	case result := <-ch:
+		return result
+	case <-time.After(2 * time.Second):
+		t.Fatal(message)
+		var zero T
+		return zero
+	}
+}
+
+func waitForCondition(t *testing.T, condition func() bool, message string) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for !condition() {
+		if time.Now().After(deadline) {
+			t.Fatal(message)
+		}
+		time.Sleep(time.Millisecond)
+	}
+}
 
 // TestConcurrentReadWrite verifies that ReadMsg and WriteMsg can be called
 // concurrently on the same MsgConn without data races or deadlocks by sending a
@@ -121,21 +253,74 @@ func TestConcurrentReadWrite(t *testing.T) {
 // Expected: Deadlines trigger appropriate timeout errors; setting deadlines does not leak
 // goroutines or prevent I/O from returning.
 func TestDeadlineInteractionUnderConcurrency(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	conn := newConcurrencyTestConn()
+	h := newConcurrencyTestHandle(conn, 1)
+
+	readErr := make(chan error, 1)
+	go func() {
+		_, err := h.ReadMsg(make([]byte, 1))
+		readErr <- err
+	}()
+
+	var wg sync.WaitGroup
+	for range 16 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			assert.NilError(t, h.SetReadDeadline(time.Now().Add(20*time.Millisecond)))
+			assert.NilError(t, h.SetWriteDeadline(time.Now().Add(20*time.Millisecond)))
+		}()
+	}
+	wg.Wait()
+
+	err := waitForResult(t, readErr, "a deadline did not unblock ReadMsg")
+	assert.Check(t, errors.Is(err, os.ErrDeadlineExceeded))
+	assert.NilError(t, h.Close())
 }
 
-// TestCloseUnblocksInFlightOperations verifies that calling Close on a connection
-// unblocks any in-flight ReadMsg, Read, WriteMsg, or Write calls.
+// TestCloseUnblocksInFlightOperations verifies that calling Close on a
+// connection unblocks in-flight reads and does not wait behind in-flight writes.
 //
 // Steps:
-// 1. Start a goroutine blocking on ReadMsg (or Read).
-// 2. Start a goroutine blocking on WriteMsg (or Write) by providing no remote peer.
+// 1. Start goroutines blocking on ReadMsg.
+// 2. Start a goroutine blocked inside the underlying WriteMsgUDP.
 // 3. Invoke Close from the main goroutine.
-// 4. Wait for blocked operations to return.
+// 4. Verify Close and the reads return before releasing the write.
 //
-// Expected: All blocked calls return promptly with an error indicating the connection is closed.
+// Expected: Reads return EOF and socket I/O never holds the session lock needed
+// by Close. An already in-flight write may complete independently.
 func TestCloseUnblocksInFlightOperations(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	conn := newConcurrencyTestConn()
+	conn.blockTransport = true
+	h := newConcurrencyTestHandle(conn, 1)
+
+	const readers = 2
+	readErrs := make(chan error, readers)
+	for range readers {
+		go func() {
+			_, err := h.ReadMsg(make([]byte, 1))
+			readErrs <- err
+		}()
+	}
+
+	writeErr := make(chan error, 1)
+	go func() {
+		writeErr <- h.WriteMsg([]byte("blocked"))
+	}()
+	<-conn.transportStarted
+
+	closeErr := make(chan error, 1)
+	go func() {
+		closeErr <- h.Close()
+	}()
+	assert.NilError(t, waitForResult(t, closeErr, "Close blocked behind an in-flight write"))
+
+	for range readers {
+		assert.Check(t, errors.Is(waitForResult(t, readErrs, "Close did not unblock a reader"), io.EOF))
+	}
+
+	close(conn.releaseTransport)
+	assert.NilError(t, waitForResult(t, writeErr, "the released write did not return"))
 }
 
 // TestBufferedDataReturnedAfterClose confirms that ReadMsg/Read can return buffered data
@@ -149,7 +334,19 @@ func TestCloseUnblocksInFlightOperations(t *testing.T) {
 //
 // Expected: Buffered messages are delivered; after exhaustion, reads return EOF.
 func TestBufferedDataReturnedAfterClose(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	h := newConcurrencyTestHandle(newConcurrencyTestConn(), 2)
+	h.recv.C <- []byte("one")
+	h.recv.C <- []byte("two")
+	assert.NilError(t, h.Close())
+
+	buf := make([]byte, 3)
+	for _, want := range []string{"one", "two"} {
+		n, err := h.ReadMsg(buf)
+		assert.NilError(t, err)
+		assert.Equal(t, string(buf[:n]), want)
+	}
+	_, err := h.ReadMsg(buf)
+	assert.Check(t, errors.Is(err, io.EOF))
 }
 
 // TestWriteFailsAfterClose ensures that any WriteMsg/Write performed after Close
@@ -161,7 +358,13 @@ func TestBufferedDataReturnedAfterClose(t *testing.T) {
 //
 // Expected: Writes return a "use of closed network connection" or equivalent error.
 func TestWriteFailsAfterClose(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	h := newConcurrencyTestHandle(newConcurrencyTestConn(), 1)
+	assert.NilError(t, h.Close())
+
+	assert.Check(t, errors.Is(h.WriteMsg([]byte("late")), io.EOF))
+	n, err := h.Write([]byte("late"))
+	assert.Equal(t, n, 0)
+	assert.Check(t, errors.Is(err, io.EOF))
 }
 
 // TestIdempotentClose validates that multiple calls to Close do not cause panics or
@@ -173,7 +376,23 @@ func TestWriteFailsAfterClose(t *testing.T) {
 //
 // Expected: Subsequent Close calls return a consistent error or nil and do not panic.
 func TestIdempotentClose(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	conn := newConcurrencyTestConn()
+	h := newConcurrencyTestHandle(conn, 1)
+
+	const closers = 64
+	errs := make(chan error, closers)
+	for range closers {
+		go func() {
+			errs <- h.Close()
+		}()
+	}
+	for range closers {
+		assert.NilError(t, waitForResult(t, errs, "concurrent Close calls deadlocked"))
+	}
+
+	conn.packetsMu.Lock()
+	defer conn.packetsMu.Unlock()
+	assert.Equal(t, len(conn.packets), 0, "local Close should not perform socket I/O")
 }
 
 // TestPeerInitiatedClose tests behavior when the remote endpoint closes the connection.
@@ -184,7 +403,41 @@ func TestIdempotentClose(t *testing.T) {
 //
 // Expected: Reads return EOF or closed error; writes return closed connection error.
 func TestPeerInitiatedClose(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	pc, err := net.ListenPacket("udp", "localhost:0")
+	assert.NilError(t, err)
+	serverCfg, verifyCfg := newTestServerConfig(t)
+	srv, err := NewServer(pc.(*net.UDPConn), *serverCfg)
+	assert.NilError(t, err)
+	go func() {
+		_ = srv.Serve()
+	}()
+	t.Cleanup(func() {
+		assert.NilError(t, srv.Close())
+	})
+
+	kp, leaf := newClientAuth(t)
+	cli, err := Dial("udp", pc.LocalAddr().String(), ClientConfig{
+		Verify:    *verifyCfg,
+		Exchanger: kp,
+		Leaf:      leaf,
+	})
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		assert.NilError(t, cli.Close())
+	})
+	assert.NilError(t, cli.Handshake())
+
+	peer, err := srv.AcceptTimeout(time.Second)
+	assert.NilError(t, err)
+	assert.NilError(t, peer.send(MessageTypeControl, []byte{byte(ControlMessageClose)}))
+
+	waitForCondition(t, cli.ss.handle.IsClosed, "peer close was not observed by the client")
+	assert.NilError(t, peer.WriteMsg([]byte("late")))
+	time.Sleep(10 * time.Millisecond)
+	_, err = cli.ReadMsg(make([]byte, 1))
+	assert.Check(t, errors.Is(err, io.EOF))
+	assert.Check(t, errors.Is(cli.WriteMsg([]byte("late")), io.EOF))
+	assert.NilError(t, peer.Close())
 }
 
 // TestRaceBetweenCloseAndDeadlineOrIO stresses race conditions by invoking Close,
@@ -197,7 +450,30 @@ func TestPeerInitiatedClose(t *testing.T) {
 //
 // Expected: No data races, deadlocks, or unexpected panics.
 func TestRaceBetweenCloseAndDeadlineOrIO(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	conn := newConcurrencyTestConn()
+	h := newConcurrencyTestHandle(conn, 64)
+
+	var wg sync.WaitGroup
+	for i := 0; i < 16; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			for j := 0; j < 50; j++ {
+				switch (i + j) % 4 {
+				case 0:
+					_ = h.WriteMsg([]byte{byte(i), byte(j)})
+				case 1:
+					_ = h.SetReadDeadline(time.Now().Add(time.Millisecond))
+				case 2:
+					_, _ = h.ReadMsg(make([]byte, 2))
+				case 3:
+					_ = h.Close()
+				}
+			}
+		}(i)
+	}
+	wg.Wait()
+	assert.Check(t, h.IsClosed())
 }
 
 // TestStressHighConcurrency subjects the connection to high-volume, concurrent reads,
@@ -210,5 +486,179 @@ func TestRaceBetweenCloseAndDeadlineOrIO(t *testing.T) {
 //
 // Expected: Stability under load with correct semantics.
 func TestStressHighConcurrency(t *testing.T) {
-	// TODO(dadrian)[2025-08-02]: Implement this.
+	conn := newConcurrencyTestConn()
+	h := newConcurrencyTestHandle(conn, 1)
+
+	const writers = 128
+	var wg sync.WaitGroup
+	for i := 0; i < writers; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			assert.NilError(t, h.WriteMsg([]byte{byte(i)}))
+		}(i)
+	}
+	wg.Wait()
+
+	conn.packetsMu.Lock()
+	assert.Equal(t, len(conn.packets), writers)
+	counters := make(map[uint64]struct{}, writers)
+	for _, pkt := range conn.packets {
+		counter := binary.BigEndian.Uint64(pkt[HeaderLen+SessionIDLen : AssociatedDataLen])
+		counters[counter] = struct{}{}
+	}
+	conn.packetsMu.Unlock()
+	assert.Equal(t, len(counters), writers, "concurrent writes reused a packet counter")
+	assert.NilError(t, h.Close())
+}
+
+func TestClientCloseInterruptsHandshake(t *testing.T) {
+	conn := newConcurrencyTestConn()
+	_, verify := newTestServerConfig(t)
+	kp, leaf := newClientAuth(t)
+	client := NewClient(conn, conn.RemoteAddr().(*net.UDPAddr), ClientConfig{
+		Verify:    *verify,
+		Exchanger: kp,
+		Leaf:      leaf,
+	})
+
+	handshakeErr := make(chan error, 1)
+	go func() {
+		handshakeErr <- client.Handshake()
+	}()
+	<-conn.readStarted
+
+	closeErr := make(chan error, 1)
+	go func() {
+		closeErr <- client.Close()
+	}()
+	assert.NilError(t, waitForResult(t, closeErr, "Close did not interrupt an in-flight handshake"))
+	assert.Check(t, errors.Is(waitForResult(t, handshakeErr, "the interrupted handshake did not return"), io.EOF))
+	assert.Check(t, client.IsClosed())
+	assert.Equal(t, conn.closeN.Load(), int32(1))
+}
+
+func TestConcurrentHandshakeRunsOnce(t *testing.T) {
+	pc, err := net.ListenPacket("udp", "localhost:0")
+	assert.NilError(t, err)
+	serverCfg, verifyCfg := newTestServerConfig(t)
+	server, err := NewServer(pc.(*net.UDPConn), *serverCfg)
+	assert.NilError(t, err)
+	go func() {
+		_ = server.Serve()
+	}()
+	t.Cleanup(func() {
+		assert.NilError(t, server.Close())
+	})
+
+	kp, leaf := newClientAuth(t)
+	client, err := Dial("udp", pc.LocalAddr().String(), ClientConfig{
+		Verify:    *verifyCfg,
+		Exchanger: kp,
+		Leaf:      leaf,
+	})
+	assert.NilError(t, err)
+	t.Cleanup(func() {
+		assert.NilError(t, client.Close())
+	})
+
+	const callers = 32
+	errs := make(chan error, callers)
+	for range callers {
+		go func() {
+			errs <- client.Handshake()
+		}()
+	}
+	for range callers {
+		assert.NilError(t, waitForResult(t, errs, "concurrent Handshake calls deadlocked"))
+	}
+
+	peer, err := server.AcceptTimeout(time.Second)
+	assert.NilError(t, err)
+	assert.NilError(t, peer.Close())
+	peer, err = server.AcceptTimeout(20 * time.Millisecond)
+	assert.Check(t, peer == nil)
+	assert.Equal(t, err, ErrTimeout, "concurrent callers performed more than one handshake")
+}
+
+func TestConcurrentClientCloseBeforeHandshake(t *testing.T) {
+	conn := newConcurrencyTestConn()
+	client := NewClient(conn, conn.RemoteAddr().(*net.UDPAddr), ClientConfig{})
+
+	const closers = 64
+	errs := make(chan error, closers)
+	for range closers {
+		go func() {
+			errs <- client.Close()
+		}()
+	}
+	for range closers {
+		assert.NilError(t, waitForResult(t, errs, "concurrent Client.Close calls deadlocked"))
+	}
+
+	assert.Check(t, client.IsClosed())
+	assert.Equal(t, conn.closeN.Load(), int32(1))
+	_, err := client.Read(make([]byte, 1))
+	assert.Check(t, errors.Is(err, io.EOF))
+}
+
+func TestServerServeCloseRace(t *testing.T) {
+	for range 100 {
+		conn := newConcurrencyTestConn()
+		config, _ := newTestServerConfig(t)
+		server, err := NewServer(conn, *config)
+		assert.NilError(t, err)
+
+		serveErr := make(chan error, 1)
+		closeErr := make(chan error, 1)
+		go func() {
+			serveErr <- server.Serve()
+		}()
+		go func() {
+			closeErr <- server.Close()
+		}()
+
+		assert.NilError(t, waitForResult(t, closeErr, "Server.Close deadlocked racing with Serve"))
+		err = waitForResult(t, serveErr, "Serve did not return after Close")
+		if err != nil {
+			assert.ErrorContains(t, err, "non-ready Server")
+		}
+		assert.Equal(t, server.state.Load(), uint32(serverStateClosed))
+		assert.Equal(t, conn.closeN.Load(), int32(1))
+	}
+}
+
+func TestConcurrentServerCloseUnblocksAccept(t *testing.T) {
+	conn := newConcurrencyTestConn()
+	config, _ := newTestServerConfig(t)
+	server, err := NewServer(conn, *config)
+	assert.NilError(t, err)
+
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.Serve()
+	}()
+
+	acceptErr := make(chan error, 1)
+	go func() {
+		_, err := server.Accept()
+		acceptErr <- err
+	}()
+
+	const closers = 64
+	closeErrs := make(chan error, closers)
+	for range closers {
+		go func() {
+			closeErrs <- server.Close()
+		}()
+	}
+	for range closers {
+		assert.NilError(t, waitForResult(t, closeErrs, "concurrent Server.Close calls deadlocked"))
+	}
+	err = waitForResult(t, serveErr, "Serve was not unblocked by Close")
+	if err != nil {
+		assert.ErrorContains(t, err, "non-ready Server")
+	}
+	assert.Check(t, errors.Is(waitForResult(t, acceptErr, "Accept was not unblocked by Close"), io.EOF))
+	assert.Equal(t, conn.closeN.Load(), int32(1))
 }

--- a/transport/doc.go
+++ b/transport/doc.go
@@ -1,2 +1,20 @@
 // Package transport implements the Hop Transport Protocol.
+//
+// # Concurrency model
+//
+// Client and Server lifecycle state is atomic: a successful state transition
+// elects one goroutine to perform an operation, while later callers wait on a
+// completion channel. Results are stored before that channel is closed, so its
+// close both broadcasts completion and publishes the results to every waiter.
+//
+// Wait groups count only goroutines that have already been started. A Server's
+// lifecycle lock makes registering a Serve call atomic with Close, and the
+// lifecycle owner closes the underlying connection before waiting so blocked
+// I/O cannot prevent shutdown.
+//
+// A SessionState mutex protects session lifecycle, counters, and cryptographic
+// state. Handle's read and write locks serialize their respective operations.
+// Packet state is updated while locked, but socket I/O happens after releasing
+// the session mutex. SessionState.closeLocked is the sole session-close
+// transition and closes the receive queue to unblock all readers.
 package transport

--- a/transport/handle.go
+++ b/transport/handle.go
@@ -13,7 +13,8 @@ import (
 
 // Handle implements net.Conn and MsgConn for connections accepted by a Server.
 type Handle struct {
-	readLock sync.Mutex
+	readLock  sync.Mutex
+	writeLock sync.Mutex
 
 	underlying UDPLike                      // outgoing socket-like
 	recv       *common.DeadlineChan[[]byte] // incoming transport messages
@@ -153,35 +154,44 @@ func (c *Handle) Write(buf []byte) (int, error) {
 	return total, nil
 }
 
-// writeControl writes a control message to the remote host
-// TODO(hosono) fix lint error
-// nolint
-func (c *Handle) writeControlLocked(msg ControlMessage) error {
-	return c.ss.writePacketLocked(c.underlying, MessageTypeControl, []byte{byte(msg)}, c.ss.writeKey)
-}
-
 func (c *Handle) send(msgType MessageType, b []byte) error {
+	// Preserve packet write order without holding the session lock during
+	// socket I/O. Close only needs the session lock, so a blocked write cannot
+	// prevent it from completing.
+	c.writeLock.Lock()
+	defer c.writeLock.Unlock()
+
 	c.ss.m.Lock()
-	defer c.ss.m.Unlock()
 	if c.ss.handleState == closed {
+		c.ss.m.Unlock()
 		return io.EOF
 	}
-	err := c.ss.writePacketLocked(c.underlying, msgType, b, c.ss.writeKey)
+	pkt, err := c.ss.sealPacketLocked(msgType, b, c.ss.writeKey)
+	remoteAddr := c.ss.remoteAddr
+	c.ss.m.Unlock()
 	if err != nil {
-		// TODO(dadrian)[2023-09-08]: Is this necessary or correct?
 		go c.Close()
+		return err
 	}
-	return err
+
+	written, _, err := c.underlying.WriteMsgUDP(pkt, nil, remoteAddr)
+	if err != nil {
+		go c.Close()
+		return err
+	}
+	if written != len(pkt) {
+		// Should never happen for a datagram-oriented connection.
+		return io.ErrShortWrite
+	}
+	return nil
 }
 
 // Close closes the connection. Future operations on non-buffered data will return io.EOF.
 func (c *Handle) Close() error {
 	c.ss.m.Lock()
 	defer c.ss.m.Unlock()
-
-	c.recv.Close()
-
-	return c.ss.closeLocked()
+	err := c.ss.closeLocked()
+	return err
 }
 
 // FetchClientLeaf returns the certificate the client presented when setting up the connection

--- a/transport/handle.go
+++ b/transport/handle.go
@@ -16,8 +16,10 @@ type Handle struct {
 	readLock  sync.Mutex
 	writeLock sync.Mutex
 
-	underlying UDPLike                      // outgoing socket-like
-	recv       *common.DeadlineChan[[]byte] // incoming transport messages
+	underlying UDPLike // outgoing socket-like
+	// recv contains decrypted messages accepted by the Client or Server receive
+	// loop but not yet returned to this Handle's reader.
+	recv *common.DeadlineChan[[]byte]
 
 	// +checklocks:readLock
 	buf bytes.Buffer
@@ -42,8 +44,9 @@ func newHandleForSession(underlying UDPLike, ss *SessionState, leaf *certs.Certi
 	}
 }
 
-// IsClosed returns true if the handle is closed or in the process of closing.
-// Writes and reads to the handle return io.EOF if and only if IsClosed returns true
+// IsClosed reports whether the session close transition has occurred. Operations
+// that start after it returns true get io.EOF once buffered reads are drained;
+// an already in-flight write may still finish.
 func (c *Handle) IsClosed() bool {
 	c.ss.m.Lock()
 	defer c.ss.m.Unlock()
@@ -118,8 +121,9 @@ func (c *Handle) Read(b []byte) (int, error) {
 	return n, err
 }
 
-// WriteMsg writes b as a single packet. If b is too long, WriteMsg returns
-// ErrBufOverlow.
+// WriteMsg writes b as a single packet. A successful return means the configured
+// UDPLike transport accepted it, not that the peer received it. If b is too
+// long, WriteMsg returns ErrBufOverlow.
 func (c *Handle) WriteMsg(b []byte) error {
 	if len(b) > MaxPlaintextSize {
 		return ErrBufOverflow
@@ -127,9 +131,9 @@ func (c *Handle) WriteMsg(b []byte) error {
 	return c.send(MessageTypeTransport, b)
 }
 
-// Write implements io.Writer. It will split b into segments of length
-// MaxPlaintextLength and send them using WriteMsg. Each call to WriteMsg is
-// subject to the timeout.
+// Write implements io.Writer. It splits b into transport packets and returns
+// after the configured UDPLike transport accepts each packet; it does not wait
+// for peer receipt.
 func (c *Handle) Write(buf []byte) (int, error) {
 	b := append([]byte{}, buf...)
 	if len(b) <= MaxPlaintextSize {
@@ -223,11 +227,9 @@ func (c *Handle) SetReadDeadline(t time.Time) error {
 	return c.recv.SetDeadline(t)
 }
 
-// SetWriteDeadline sets a deadline at which future read operations will stop
-// Pending writes will be canceled
+// SetWriteDeadline currently records no deadline. Writes remain subject to
+// writeLock and the configured underlying transport.
 func (c *Handle) SetWriteDeadline(_ time.Time) error {
-	// There is no actual write deadline because sends go out immediately, subject to locking.
-	//
 	// TODO(dadrian)[2023-09-08]: Somehow limit lock wait time to write deadline.
 	return nil
 }

--- a/transport/server.go
+++ b/transport/server.go
@@ -45,14 +45,20 @@ type Server struct {
 	// +checklocks:m
 	sessions map[SessionID]*SessionState
 
+	// pendingConnections contains established Handles published by the Serve
+	// receive loop but not yet returned by Accept. Close stops that producer
+	// before closing the queue.
 	pendingConnections chan *Handle
 
 	// +checklocks:cookieLock
-	cookieKey        [KeyLen]byte
-	cookieLock       sync.Mutex
+	cookieKey  [KeyLen]byte
+	cookieLock sync.Mutex
+	// stopCookieRotate is closed once by the shutdown owner.
 	stopCookieRotate chan struct{}
 
-	wg        sync.WaitGroup
+	wg sync.WaitGroup
+	// closeDone closes after all workers and session receive queues stop and
+	// closeErr is stored, publishing the result to later Close and Serve calls.
 	closeDone chan struct{}
 	closeErr  error
 }

--- a/transport/server.go
+++ b/transport/server.go
@@ -33,6 +33,8 @@ const (
 type Server struct {
 	m sync.RWMutex
 
+	lifecycleMu sync.Mutex
+
 	udpConn UDPLike
 	config  ServerConfig
 
@@ -51,7 +53,8 @@ type Server struct {
 	stopCookieRotate chan struct{}
 
 	wg        sync.WaitGroup
-	closeWait sync.WaitGroup
+	closeDone chan struct{}
+	closeErr  error
 }
 
 func (s *Server) setHandshakeState(remoteAddr *net.UDPAddr, hs *HandshakeState) bool {
@@ -124,12 +127,6 @@ func (s *Server) fetchSession(sessionID SessionID) *SessionState {
 // +checklocksread:s.m
 func (s *Server) fetchSessionLocked(sessionID SessionID) *SessionState {
 	return s.sessions[sessionID]
-}
-
-func (s *Server) stopTrackingSession(sessionID SessionID) {
-	s.m.Lock()
-	defer s.m.Unlock()
-	s.stopTrackingSessionLocked(sessionID)
 }
 
 // +checklocks:s.m
@@ -468,6 +465,9 @@ func (s *Server) handleSessionMessage(addr *net.UDPAddr, msg []byte) error {
 	}
 	ss.m.Lock()
 	defer ss.m.Unlock()
+	if ss.handleState == closed {
+		return nil
+	}
 
 	// TODO(dadrian): Can we avoid this allocation?
 	plaintext := make([]byte, PlaintextLen(len(msg)))
@@ -505,12 +505,13 @@ func (s *Server) handleSessionMessage(addr *net.UDPAddr, msg []byte) error {
 
 // Serve blocks until the server is closed.
 func (s *Server) Serve() error {
-	// TODO(dadrian)[2023-09-09]: Handle the case where this function is
-	// erroneously called twice.
+	s.lifecycleMu.Lock()
 	if !s.state.CompareAndSwap(uint32(serverStateReady), uint32(serverStateServing)) {
+		s.lifecycleMu.Unlock()
 		return errors.New("Serve called on non-ready Server")
 	}
-	s.wg.Add(3)
+	s.wg.Add(2)
+	s.lifecycleMu.Unlock()
 
 	go func() {
 		defer s.wg.Done()
@@ -553,8 +554,8 @@ func (s *Server) Serve() error {
 		}
 	}()
 
-	s.wg.Done()
 	s.wg.Wait()
+	<-s.closeDone
 	return nil
 }
 
@@ -715,6 +716,7 @@ func (s *Server) Accept() (*Handle, error) {
 func (s *Server) AcceptTimeout(duration time.Duration) (*Handle, error) {
 	logrus.Debug("accept timeout started")
 	timer := time.NewTimer(duration)
+	defer timer.Stop()
 	select {
 	case handle, ok := <-s.pendingConnections:
 		if ok {
@@ -734,62 +736,48 @@ func (s *Server) Addr() net.Addr {
 
 // Close stops the server, causing Serve() to return.
 func (s *Server) Close() (err error) {
-	s.closeWait.Add(1)
-	for !s.state.CompareAndSwap(uint32(serverStateServing), uint32(serverStateClosing)) {
+	s.lifecycleMu.Lock()
+	for {
 		cur := serverState(s.state.Load())
 		switch cur {
-		case serverStateReady:
-			if s.state.CompareAndSwap(uint32(serverStateReady), uint32(serverStateClosed)) {
-				s.closeWait.Done()
-				return nil
+		case serverStateClosing, serverStateClosed:
+			s.lifecycleMu.Unlock()
+			<-s.closeDone
+			return s.closeErr
+		default:
+			if s.state.CompareAndSwap(uint32(cur), uint32(serverStateClosing)) {
+				s.lifecycleMu.Unlock()
+				goto closing
 			}
-		case serverStateClosing:
-			s.closeWait.Done()
-			s.closeWait.Wait()
-			return nil
-		case serverStateClosed:
-			s.closeWait.Done()
-			return nil
 		}
 	}
-	defer s.closeWait.Done()
 
-	// Stop reading packets
-	s.udpConn.SetReadDeadline(time.Now())
-	// Stop rotating cookies inside readPacket
+closing:
+	// Closing the socket unblocks both the Serve read loop and any in-flight
+	// writes before we wait for workers or acquire per-session locks.
+	s.closeErr = s.udpConn.Close()
 	close(s.stopCookieRotate)
-	// Wait for read packet to finish
 	s.wg.Wait()
 
-	// Close the channels
+	s.m.Lock()
 	close(s.pendingConnections)
+	sessions := make([]*SessionState, 0, len(s.sessions))
+	for _, ss := range s.sessions {
+		sessions = append(sessions, ss)
+	}
+	clear(s.handshakes)
+	clear(s.sessions)
+	s.m.Unlock()
 
-	// Drain everything and close the connections
-	wg := sync.WaitGroup{}
-	func() {
-		s.m.Lock()
-		defer s.m.Unlock()
-		for h := range s.pendingConnections {
-			wg.Add(1)
-			go func(h *Handle) {
-				defer wg.Done()
-				h.Close()
-			}(h)
+	for _, ss := range sessions {
+		if ss.handle != nil {
+			_ = ss.handle.Close()
 		}
-		for _, ss := range s.sessions {
-			wg.Add(1)
-			go func(ss *SessionState) {
-				defer wg.Done()
-				if ss.handle != nil {
-					ss.handle.Close()
-				}
-				s.stopTrackingSession(ss.sessionID)
-			}(ss)
-		}
-	}()
-	wg.Wait()
-	s.udpConn.Close()
-	return nil
+	}
+
+	s.state.Store(uint32(serverStateClosed))
+	close(s.closeDone)
+	return s.closeErr
 }
 
 func (s *Server) init() error {
@@ -860,6 +848,7 @@ func NewServer(conn UDPLike, config ServerConfig) (*Server, error) {
 		udpConn:          conn,
 		config:           config,
 		stopCookieRotate: make(chan struct{}),
+		closeDone:        make(chan struct{}),
 	}
 	err := s.init()
 	return &s, err

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -15,8 +15,10 @@ import (
 // SessionID is an IP-independent identifier of a tunnel.
 type SessionID [4]byte
 
-// SessionState contains the cryptographic state associated with a SessionID
-// after the successful completion of a handshake.
+// SessionState contains the cryptographic and lifecycle state associated with a
+// SessionID after a successful handshake. Its mutex orders packet processing
+// with closeLocked, so receive producers reject work before the Handle receive
+// queue is canceled.
 type SessionState struct {
 	sessionID SessionID
 

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -103,7 +103,7 @@ func (ss *SessionState) readCounter(b []byte) (count uint64) {
 	return
 }
 
-func (ss *SessionState) writePacketLocked(conn UDPLike, msgType MessageType, in []byte, key *[KeyLen]byte) error {
+func (ss *SessionState) sealPacketLocked(msgType MessageType, in []byte, key *[KeyLen]byte) ([]byte, error) {
 	length := HeaderLen + SessionIDLen + CounterLen + len(in) + TagLen
 	ss.rawWrite.Reset()
 	if ss.rawWrite.Cap() < length {
@@ -128,7 +128,7 @@ func (ss *SessionState) writePacketLocked(conn UDPLike, msgType MessageType, in 
 	// no nonce. The output has an overhead of TagLength.
 	aead, err := kravatte.NewSANSE(key[:])
 	if err != nil {
-		return err
+		return nil, err
 	}
 	buf := make([]byte, TagLen+len(in))
 	enc := aead.Seal(buf[:0], nil, in, ss.rawWrite.Bytes()[:AssociatedDataLen])
@@ -141,17 +141,8 @@ func (ss *SessionState) writePacketLocked(conn UDPLike, msgType MessageType, in 
 	}
 	ss.rawWrite.Write(buf)
 
-	b := ss.rawWrite.Bytes()
-	written, _, err := conn.WriteMsgUDP(b, nil, ss.remoteAddr)
-	if err != nil {
-		return err
-	}
-	if written != length {
-		// Should never happen
-		logrus.Panicf("WriteMsgUDP wrote %d, expected length %d", written, length)
-	}
 	ss.count++
-	return nil
+	return append([]byte(nil), ss.rawWrite.Bytes()...), nil
 }
 
 func (ss *SessionState) readPacketLocked(plaintext, pkt []byte, key *[KeyLen]byte) (int, MessageType, error) {
@@ -243,7 +234,9 @@ func (ss *SessionState) closeLocked() (err error) {
 	if ss.handleState == closed {
 		return nil
 	}
-	// TODO(dadrian)[2023-09-09]: Actually close. This is hard because sometimes
-	// the Server knows we're closing, and sometimes only the Handle knows.
+	ss.handleState = closed
+	if ss.handle != nil {
+		_ = ss.handle.recv.Close()
+	}
 	return nil
 }

--- a/tubes/common.go
+++ b/tubes/common.go
@@ -15,6 +15,7 @@ var ErrMuxerStopping = errors.New("muxer is stopping")
 var ErrBadTubeState = errors.New("tube in bad state")
 
 var errFrameOutOfBounds = errors.New("received data frame out of receive window bounds") // +checklocksignore
+var errTooManyDuplicateACKs = errors.New("too many duplicate acknowledgements")          // +checklocksignore
 
 // TODO(hosono) create a config struct to pass to the muxer to set these things
 

--- a/tubes/concurrency_test.go
+++ b/tubes/concurrency_test.go
@@ -1,0 +1,157 @@
+package tubes
+
+import (
+	"errors"
+	"io"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/sirupsen/logrus"
+	"gotest.tools/assert"
+
+	"hop.computer/hop/common"
+)
+
+// TestReliablePublishesClosedBeforeSenderDrain verifies that late packet
+// handlers reject new work while shutdown waits for the sender consumer.
+func TestReliablePublishesClosedBeforeSenderDrain(t *testing.T) {
+	log := logrus.WithField("test", t.Name())
+	r := &Reliable{
+		sender:     newSender(log),
+		recvWindow: newReceiver(log),
+		tubeState:  initiated,
+		closed:     make(chan struct{}),
+		sendDone:   make(chan struct{}),
+		log:        log,
+	}
+	r.l.Lock()
+	r.sender.closed.Store(false)
+	r.l.Unlock()
+
+	enterDone := make(chan struct{})
+	go func() {
+		r.l.Lock()
+		r.enterClosedState()
+		r.l.Unlock()
+		close(enterDone)
+	}()
+
+	deadline := time.Now().Add(time.Second)
+	senderClosing := false
+	for !senderClosing && time.Now().Before(deadline) {
+		r.l.Lock()
+		senderClosing = r.sender.closed.Load()
+		r.l.Unlock()
+		runtime.Gosched()
+	}
+	if !senderClosing {
+		close(r.sendDone)
+		<-enterDone
+		t.Fatal("sender did not begin closing")
+	}
+
+	r.l.Lock()
+	stateDuringDrain := r.tubeState
+	r.l.Unlock()
+
+	close(r.sendDone)
+	select {
+	case <-enterDone:
+	case <-time.After(time.Second):
+		t.Fatal("reliable close did not finish after sender drain")
+	}
+
+	assert.Equal(t, stateDuringDrain, closed)
+}
+
+// TestReliableOwnsSenderQueueClosure verifies that sender errors are reported
+// upward instead of independently closing queues owned by the Reliable.
+func TestReliableOwnsSenderQueueClosure(t *testing.T) {
+	s := newSender(logrus.WithField("test", t.Name()))
+	s.senderWindow.duplicatedAckCounter = 101
+
+	_, err := s.recvAck(25)
+	assert.Assert(t, errors.Is(err, errTooManyDuplicateACKs))
+	assert.Assert(t, !s.closed.Load(), "sender closed queues outside the Reliable lifecycle")
+
+	assert.NilError(t, s.Close())
+}
+
+// TestReliableForcedCloseStopsResponderInit verifies that shutdown wakes and
+// joins a responder initiation producer that has not received its INIT frame.
+func TestReliableForcedCloseStopsResponderInit(t *testing.T) {
+	log := logrus.WithField("test", t.Name())
+	r := &Reliable{
+		sender:     newSender(log),
+		recvWindow: newReceiver(log),
+		tubeState:  created,
+		closed:     make(chan struct{}),
+		initRecv:   make(chan struct{}),
+		initDone:   make(chan struct{}),
+		sendDone:   make(chan struct{}),
+		log:        log,
+	}
+	r.l.Lock()
+	r.sender.closed.Store(true)
+	r.l.Unlock()
+	go r.initiate(false)
+
+	r.l.Lock()
+	r.enterClosedState()
+	r.l.Unlock()
+
+	select {
+	case <-r.initDone:
+	case <-time.After(time.Second):
+		t.Fatal("forced close did not stop responder initiation")
+	}
+	r.WaitForClose()
+}
+
+// TestUnreliableCloseQueuesFINLast verifies that Close stops writers before
+// placing the FIN behind every message already accepted into the local queue.
+func TestUnreliableCloseQueuesFINLast(t *testing.T) {
+	initiatedCh := make(chan struct{})
+	close(initiatedCh)
+	initiateDone := make(chan struct{})
+	close(initiateDone)
+	u := &Unreliable{
+		sendQueue:    make(chan []byte, 2),
+		initiated:    initiatedCh,
+		initiateDone: initiateDone,
+		stopInitiate: make(chan struct{}),
+		senderDone:   make(chan struct{}),
+		closed:       make(chan struct{}),
+		recv:         common.NewDeadlineChan[[]byte](1),
+		send:         common.NewDeadlineChan[[]byte](1),
+		log:          logrus.WithField("test", t.Name()),
+	}
+	u.state.Store(initiated)
+	go u.sender()
+
+	assert.NilError(t, u.WriteMsg([]byte("before close")))
+	assert.NilError(t, u.Close())
+	assert.Assert(t, errors.Is(u.WriteMsg([]byte("after close")), io.EOF))
+
+	dataFrame, err := fromBytes(<-u.sendQueue)
+	assert.NilError(t, err)
+	assert.Assert(t, !dataFrame.flags.FIN)
+
+	finFrame, err := fromBytes(<-u.sendQueue)
+	assert.NilError(t, err)
+	assert.Assert(t, finFrame.flags.FIN)
+}
+
+// TestUnreliableRejectsReceiveAfterClose verifies that the receive producer
+// cannot enqueue new buffered data after lifecycle shutdown is published.
+func TestUnreliableRejectsReceiveAfterClose(t *testing.T) {
+	u := &Unreliable{
+		recv: common.NewDeadlineChan[[]byte](1),
+	}
+	u.state.Store(closed)
+
+	err := u.receive(&frame{data: []byte("late"), dataLength: 4})
+	assert.Assert(t, errors.Is(err, ErrBadTubeState))
+	assert.Equal(t, len(u.recv.C), 0)
+}

--- a/tubes/concurrency_test.go
+++ b/tubes/concurrency_test.go
@@ -109,6 +109,72 @@ func TestReliableForcedCloseStopsResponderInit(t *testing.T) {
 	r.WaitForClose()
 }
 
+// TestReliableInitiationGuardStartsSenderAfterResponse verifies that a response
+// winning concurrently with a retransmit check is success, not cancellation.
+func TestReliableInitiationGuardStartsSenderAfterResponse(t *testing.T) {
+	log := logrus.WithField("test", t.Name())
+	r := &Reliable{
+		sender:     newSender(log),
+		recvWindow: newReceiver(log),
+		sendQueue:  make(chan []byte, 1),
+		tubeState:  created,
+		closed:     make(chan struct{}),
+		initRecv:   make(chan struct{}),
+		initDone:   make(chan struct{}),
+		sendDone:   make(chan struct{}),
+		log:        log,
+	}
+	r.l.Lock()
+	r.sender.closed.Store(true)
+	r.l.Unlock()
+
+	assert.NilError(t, r.receiveInitiatePkt(&initiateFrame{
+		flags: frameFlags{RESP: true, REL: true},
+	}))
+	r.initiate(true)
+
+	r.l.Lock()
+	senderStarted := !r.sender.closed.Load()
+	r.l.Unlock()
+	if !senderStarted {
+		t.Fatal("successful initiation did not enable the reliable sender")
+	}
+
+	r.sender.sendQueue <- &frame{data: []byte("started"), dataLength: 7}
+	select {
+	case <-r.sendQueue:
+	case <-time.After(time.Second):
+		t.Fatal("reliable sender did not hand queued frame to the muxer")
+	}
+
+	r.l.Lock()
+	r.enterClosedState()
+	r.l.Unlock()
+	r.WaitForClose()
+}
+
+// TestReliableForcedCloseBeforeSenderStart verifies that an initiated state does
+// not imply a sender exists until startup enables it under the lifecycle lock.
+func TestReliableForcedCloseBeforeSenderStart(t *testing.T) {
+	log := logrus.WithField("test", t.Name())
+	r := &Reliable{
+		sender:     newSender(log),
+		recvWindow: newReceiver(log),
+		tubeState:  initiated,
+		closed:     make(chan struct{}),
+		initDone:   make(chan struct{}),
+		sendDone:   make(chan struct{}),
+		log:        log,
+	}
+	r.l.Lock()
+	r.sender.closed.Store(true)
+	r.enterClosedState()
+	r.l.Unlock()
+	close(r.initDone)
+
+	r.WaitForClose()
+}
+
 // TestUnreliableCloseQueuesFINLast verifies that Close stops writers before
 // placing the FIN behind every message already accepted into the local queue.
 func TestUnreliableCloseQueuesFINLast(t *testing.T) {
@@ -141,6 +207,44 @@ func TestUnreliableCloseQueuesFINLast(t *testing.T) {
 	finFrame, err := fromBytes(<-u.sendQueue)
 	assert.NilError(t, err)
 	assert.Assert(t, finFrame.flags.FIN)
+}
+
+// TestUnreliableInitiationGuardStartsSenderAfterResponse verifies that a
+// response observed at the retransmit guard still starts the sender consumer.
+func TestUnreliableInitiationGuardStartsSenderAfterResponse(t *testing.T) {
+	u := &Unreliable{
+		sendQueue:    make(chan []byte, 2),
+		initiated:    make(chan struct{}),
+		initiateDone: make(chan struct{}),
+		stopInitiate: make(chan struct{}),
+		senderDone:   make(chan struct{}),
+		closed:       make(chan struct{}),
+		recv:         common.NewDeadlineChan[[]byte](1),
+		send:         common.NewDeadlineChan[[]byte](2),
+		log:          logrus.WithField("test", t.Name()),
+	}
+	u.state.Store(created)
+
+	assert.NilError(t, u.receiveInitiatePkt(&initiateFrame{
+		flags: frameFlags{RESP: true},
+	}))
+	u.initiate(true)
+
+	select {
+	case <-u.senderDone:
+		t.Fatal("successful initiation was treated as sender cancellation")
+	default:
+	}
+
+	assert.NilError(t, u.send.Send([]byte("started")))
+	select {
+	case got := <-u.sendQueue:
+		assert.DeepEqual(t, got, []byte("started"))
+	case <-time.After(time.Second):
+		t.Fatal("unreliable sender did not hand queued message to the muxer")
+	}
+
+	assert.NilError(t, u.Close())
 }
 
 // TestUnreliableRejectsReceiveAfterClose verifies that the receive producer

--- a/tubes/doc.go
+++ b/tubes/doc.go
@@ -12,10 +12,11 @@
 // the lifecycle mutex while waiting for the tube sender to drain, and actual
 // socket I/O belongs solely to the Muxer sender.
 //
-// Shutdown proceeds from producers to consumers. Tubes close and drain their
-// sender queues before the Muxer closes its queues. The Muxer sender then gets a
-// bounded drain period before the underlying connection is closed to stop the
-// receiver. This ordering normally writes the final reliable FIN acknowledgement
-// and ensures no goroutine can send on a closed queue; the bound prevents a stuck
-// transport write from deadlocking shutdown.
+// Shutdown proceeds from producers to consumers. Tubes reject new work, close
+// and drain their sender queues, and then the Muxer closes its queues. One
+// shutdown deadline bounds that entire chain: on expiry, closing the underlying
+// connection unblocks the Muxer sender, which drains queued handoffs so upstream
+// producers can exit. This ordering normally writes the final reliable FIN
+// acknowledgement, never sends on a closed queue, and cannot wait forever on a
+// stuck transport write.
 package tubes

--- a/tubes/doc.go
+++ b/tubes/doc.go
@@ -1,0 +1,20 @@
+// Package tubes multiplexes raw data into logical channels of a Hop session.
+//
+// # Concurrency model
+//
+// A Muxer owns one receiver and one sender goroutine. Its mutex protects the
+// tube maps and elects the first Stop caller as the shutdown owner; later calls
+// wait for the stopped channel, whose close publishes the cached results.
+//
+// Each Reliable's lifecycle mutex serializes state-machine transitions. Its
+// sender has a separate mutex for acknowledgements and retransmission state;
+// when both are needed, the Reliable mutex is acquired first. State transitions
+// release these locks before waiting on another goroutine or doing socket I/O.
+//
+// Shutdown proceeds from producers to consumers. Tubes close and drain their
+// sender queues before the Muxer closes its queues; the Muxer sender then drains
+// those queues before the underlying connection is closed to stop the receiver.
+// This ordering ensures that the final reliable FIN acknowledgement is normally
+// written and that no goroutine can send on a closed queue. A bounded shutdown
+// timer closes the connection if a transport write is stuck.
+package tubes

--- a/tubes/doc.go
+++ b/tubes/doc.go
@@ -8,13 +8,14 @@
 //
 // Each Reliable's lifecycle mutex serializes state-machine transitions. Its
 // sender has a separate mutex for acknowledgements and retransmission state;
-// when both are needed, the Reliable mutex is acquired first. State transitions
-// release these locks before waiting on another goroutine or doing socket I/O.
+// when both are needed, the Reliable mutex is acquired first. Closing releases
+// the lifecycle mutex while waiting for the tube sender to drain, and actual
+// socket I/O belongs solely to the Muxer sender.
 //
 // Shutdown proceeds from producers to consumers. Tubes close and drain their
-// sender queues before the Muxer closes its queues; the Muxer sender then drains
-// those queues before the underlying connection is closed to stop the receiver.
-// This ordering ensures that the final reliable FIN acknowledgement is normally
-// written and that no goroutine can send on a closed queue. A bounded shutdown
-// timer closes the connection if a transport write is stuck.
+// sender queues before the Muxer closes its queues. The Muxer sender then gets a
+// bounded drain period before the underlying connection is closed to stop the
+// receiver. This ordering normally writes the final reliable FIN acknowledgement
+// and ensures no goroutine can send on a closed queue; the bound prevents a stuck
+// transport write from deadlocking shutdown.
 package tubes

--- a/tubes/muxer.go
+++ b/tubes/muxer.go
@@ -42,6 +42,8 @@ type Tube interface {
 
 // Muxer handles delivering and sending tube messages
 type Muxer struct {
+	// tubeQueue contains remotely initiated tubes accepted by the receiver.
+	// Once Stop publishes muxerStopping, the receiver cannot add another tube.
 	tubeQueue chan Tube
 
 	idParity byte
@@ -52,18 +54,23 @@ type Muxer struct {
 	// +checklocks:m
 	unreliableTubes map[byte]*Unreliable
 
-	// All hop tubes write raw bytes for a tube packet to this golang chan.
+	// Tube producers hand encoded frames to these queues. A successful send only
+	// means the Muxer sender accepted the frame; senderErr publishes completion
+	// after all accepted frames have either been written or discarded on error.
 	sendQueue         chan []byte
 	prioritySendQueue chan []byte
 	state             atomic.Value
-	stopped           chan struct{}
-	underlying        transport.MsgConn
-	timeout           time.Duration
-	log               *logrus.Entry
+	// stopped is closed after Stop caches both worker results.
+	stopped    chan struct{}
+	underlying transport.MsgConn
+	timeout    time.Duration
+	log        *logrus.Entry
 
+	// senderErr receives once, after the sender has drained both send queues.
 	senderErr chan error
 	sendErr   error
 
+	// receiverErr receives once, after the receiver stops reading the transport.
 	receiverErr chan error
 	recvErr     error
 
@@ -320,6 +327,7 @@ func (m *Muxer) makeUnreliableTubeWithID(tType TubeType, tubeID byte, req bool) 
 		state:        atomic.Value{},
 		initiated:    make(chan struct{}),
 		initiateDone: make(chan struct{}),
+		stopInitiate: make(chan struct{}),
 		senderDone:   make(chan struct{}),
 		closed:       make(chan struct{}),
 		log: m.log.WithFields(logrus.Fields{
@@ -366,9 +374,10 @@ func (m *Muxer) readMsg() (*frame, error) {
 
 }
 
-// sender reads data from the muxer's sendQueue and writes it to the
-// underlying MsgConn. If an error occurs while sending data, sender will call
-// m.Stop in a new goroutine and the error will be reported by m.Stop
+// sender accepts frames from the Muxer queues and writes them synchronously to
+// the underlying MsgConn. Receiving a frame is only a queue handoff; WriteMsg
+// completion is the point at which the transport has accepted it. If a write
+// fails, sender starts Stop and drains both queues so tube producers can exit.
 func (m *Muxer) sender() {
 	var err error
 	ok := true
@@ -422,8 +431,8 @@ func (m *Muxer) start() {
 func (m *Muxer) receiver() {
 	var err error
 
-	// When start finishes, it sends its error on this channel.
-	// m.Stop receives this error and passes it to the caller.
+	// When the receiver finishes, it sends its error on receiverErr. Stop
+	// receives that result before publishing shutdown completion.
 	defer func() {
 		// This case indicates that the muxer was stopped by m.Stop()
 		if m.state.Load() == muxerStopped {
@@ -501,11 +510,11 @@ func closeTubeHelper(t Tube, log *logrus.Entry, wg *sync.WaitGroup) {
 	}(t)
 }
 
-// Stop ensures all the muxer tubes are closed. Calls to Stop are idempotent.
-// If a call to Stop is make while another call to stop is ongoing, the second
-// call with block until the first call has finish. Stop returns two errors:
-// the first error is any error returned by the muxer sender and the second
-// any error returned by the muxer receiver.
+// Stop gracefully closes every tube and then the underlying transport. Its
+// bounded fallback may close the transport first to unblock that graceful
+// drain. Calls are idempotent; concurrent callers wait for the elected shutdown
+// owner to publish its result. Stop returns the sender error followed by the
+// receiver error.
 func (m *Muxer) Stop() (sendErr error, recvErr error) {
 	// This error indicates that the muxer got an ICMP Destination Unreachable packet.
 	// This happens when the other side of the connetion has been closed, so we
@@ -550,6 +559,11 @@ func (m *Muxer) Stop() (sendErr error, recvErr error) {
 		if m.state.Load() == muxerStopped {
 			return
 		}
+
+		// The graceful tube close may itself be blocked behind the Muxer sender.
+		// Close the transport first so sender can switch to draining its queues.
+		m.underlying.Close()
+
 		m.m.Lock()
 		for _, v := range m.reliableTubes {
 			go func(r *Reliable) {

--- a/tubes/muxer.go
+++ b/tubes/muxer.go
@@ -570,11 +570,20 @@ func (m *Muxer) Stop() (sendErr error, recvErr error) {
 	close(m.sendQueue)
 	close(m.tubeQueue)
 
+	// Drain every queued tube frame before closing the transport. If a transport
+	// write is stuck, Close must interrupt it so shutdown cannot deadlock.
+	senderTimer := time.NewTimer(muxerTimeout)
+	select {
+	case m.sendErr = <-m.senderErr:
+		senderTimer.Stop()
+	case <-senderTimer.C:
+		m.underlying.Close()
+		m.sendErr = <-m.senderErr
+	}
 	m.underlying.Close()
 
-	// Cache error for future calls to Stop
+	// Cache errors for future calls to Stop.
 	m.recvErr = <-m.receiverErr
-	m.sendErr = <-m.senderErr
 	m.m.Lock()
 	defer m.m.Unlock()
 

--- a/tubes/muxer_test.go
+++ b/tubes/muxer_test.go
@@ -15,6 +15,172 @@ import (
 	"hop.computer/hop/transport"
 )
 
+type blockingWriteMsgConn struct {
+	writeStarted   chan struct{}
+	releaseWrite   chan struct{}
+	writeCompleted chan struct{}
+	closed         chan struct{}
+
+	startOnce    sync.Once
+	completeOnce sync.Once
+	closeOnce    sync.Once
+}
+
+type stopResult struct {
+	sendErr error
+	recvErr error
+}
+
+func newBlockingWriteMsgConn() *blockingWriteMsgConn {
+	return &blockingWriteMsgConn{
+		writeStarted:   make(chan struct{}),
+		releaseWrite:   make(chan struct{}),
+		writeCompleted: make(chan struct{}),
+		closed:         make(chan struct{}),
+	}
+}
+
+func (c *blockingWriteMsgConn) Read(p []byte) (int, error) {
+	return c.ReadMsg(p)
+}
+
+func (c *blockingWriteMsgConn) Write(p []byte) (int, error) {
+	if err := c.WriteMsg(p); err != nil {
+		return 0, err
+	}
+	return len(p), nil
+}
+
+func (c *blockingWriteMsgConn) Close() error {
+	c.closeOnce.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}
+
+func (c *blockingWriteMsgConn) LocalAddr() net.Addr {
+	return &net.IPAddr{}
+}
+
+func (c *blockingWriteMsgConn) RemoteAddr() net.Addr {
+	return &net.IPAddr{}
+}
+
+func (c *blockingWriteMsgConn) SetDeadline(time.Time) error {
+	return nil
+}
+
+func (c *blockingWriteMsgConn) SetReadDeadline(time.Time) error {
+	return nil
+}
+
+func (c *blockingWriteMsgConn) SetWriteDeadline(time.Time) error {
+	return nil
+}
+
+func (c *blockingWriteMsgConn) ReadMsg([]byte) (int, error) {
+	<-c.closed
+	return 0, net.ErrClosed
+}
+
+func (c *blockingWriteMsgConn) WriteMsg([]byte) error {
+	c.startOnce.Do(func() {
+		close(c.writeStarted)
+	})
+
+	select {
+	case <-c.releaseWrite:
+		c.completeOnce.Do(func() {
+			close(c.writeCompleted)
+		})
+		return nil
+	case <-c.closed:
+		return net.ErrClosed
+	}
+}
+
+// TestMuxerStopDrainsSenderBeforeClosingUnderlying verifies that shutdown
+// writes every frame accepted from a tube before closing the transport.
+func TestMuxerStopDrainsSenderBeforeClosingUnderlying(t *testing.T) {
+	conn := newBlockingWriteMsgConn()
+	muxer := newMuxer(conn, time.Second, false, logrus.WithField("test", t.Name()))
+
+	muxer.sendQueue <- []byte("final reliable acknowledgement")
+	<-conn.writeStarted
+
+	stopDone := make(chan stopResult, 1)
+	go func() {
+		sendErr, recvErr := muxer.Stop()
+		stopDone <- stopResult{sendErr: sendErr, recvErr: recvErr}
+	}()
+
+	select {
+	case <-conn.closed:
+		close(conn.releaseWrite)
+		<-stopDone
+		t.Fatal("underlying connection closed while the muxer sender was writing")
+	case <-stopDone:
+		close(conn.releaseWrite)
+		t.Fatal("Muxer.Stop returned while the muxer sender was writing")
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	close(conn.releaseWrite)
+	select {
+	case result := <-stopDone:
+		assert.NilError(t, result.sendErr)
+		assert.NilError(t, result.recvErr)
+	case <-time.After(time.Second):
+		t.Fatal("Muxer.Stop did not finish after the pending write completed")
+	}
+
+	select {
+	case <-conn.writeCompleted:
+	default:
+		t.Fatal("pending write did not complete")
+	}
+	select {
+	case <-conn.closed:
+	default:
+		t.Fatal("underlying connection was not closed")
+	}
+}
+
+// TestMuxerStopInterruptsBlockedSender verifies that a stuck transport write
+// cannot deadlock shutdown after the graceful drain period expires.
+func TestMuxerStopInterruptsBlockedSender(t *testing.T) {
+	conn := newBlockingWriteMsgConn()
+	muxer := newMuxer(conn, time.Second, false, logrus.WithField("test", t.Name()))
+
+	muxer.sendQueue <- []byte("blocked write")
+	<-conn.writeStarted
+
+	stopDone := make(chan stopResult, 1)
+	go func() {
+		sendErr, recvErr := muxer.Stop()
+		stopDone <- stopResult{sendErr: sendErr, recvErr: recvErr}
+	}()
+
+	select {
+	case result := <-stopDone:
+		assert.NilError(t, result.sendErr)
+		assert.NilError(t, result.recvErr)
+	case <-time.After(2 * muxerTimeout):
+		t.Fatal("Muxer.Stop deadlocked on a blocked transport write")
+	}
+
+	select {
+	case <-conn.closed:
+	default:
+		t.Fatal("blocked transport was not closed")
+	}
+	select {
+	case <-conn.writeCompleted:
+		t.Fatal("blocked write unexpectedly completed")
+	default:
+	}
+}
+
 // makeMuxers creates two connected muxers running over UDP. Packet delivery is
 // controlled by a deterministic coin flipper with the provided bit bias.
 //

--- a/tubes/muxer_test.go
+++ b/tubes/muxer_test.go
@@ -2,6 +2,7 @@ package tubes
 
 import (
 	"net"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -178,6 +179,55 @@ func TestMuxerStopInterruptsBlockedSender(t *testing.T) {
 	case <-conn.writeCompleted:
 		t.Fatal("blocked write unexpectedly completed")
 	default:
+	}
+}
+
+// TestMuxerStopUnblocksTubeProducerOnBlockedWrite verifies that the forced
+// shutdown bound reaches upstream tube producers, not only the Muxer sender.
+func TestMuxerStopUnblocksTubeProducerOnBlockedWrite(t *testing.T) {
+	conn := newBlockingWriteMsgConn()
+	muxer := newMuxer(conn, time.Second, false, logrus.WithField("test", t.Name()))
+
+	tube, err := muxer.CreateUnreliableTube(common.ExecTube)
+	assert.NilError(t, err)
+	<-conn.writeStarted
+
+	err = tube.receiveInitiatePkt(&initiateFrame{
+		flags: frameFlags{RESP: true},
+	})
+	assert.NilError(t, err)
+	<-tube.initiateDone
+
+	err = tube.WriteMsg([]byte("queued behind blocked muxer write"))
+	assert.NilError(t, err)
+	deadline := time.Now().Add(time.Second)
+	for len(tube.send.C) != 0 && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+	assert.Equal(t, len(tube.send.C), 0, "tube sender did not consume queued message")
+
+	stopDone := make(chan stopResult, 1)
+	go func() {
+		sendErr, recvErr := muxer.Stop()
+		stopDone <- stopResult{sendErr: sendErr, recvErr: recvErr}
+	}()
+
+	select {
+	case result := <-stopDone:
+		assert.NilError(t, result.sendErr)
+		assert.NilError(t, result.recvErr)
+	case <-time.After(2 * muxerTimeout):
+		// Release the fake write so a broken Stop can clean up before the test
+		// fails rather than leaking its shutdown goroutines.
+		close(conn.releaseWrite)
+		<-stopDone
+		t.Fatal("Muxer.Stop deadlocked behind an unreliable tube producer")
+	}
+
+	select {
+	case <-conn.closed:
+	default:
+		t.Fatal("blocked transport was not closed")
 	}
 }
 

--- a/tubes/reliable.go
+++ b/tubes/reliable.go
@@ -39,8 +39,10 @@ type Reliable struct {
 	localAddr  net.Addr
 	remoteAddr net.Addr
 	// +checklocks:l
-	sender            *sender
-	recvWindow        *receiver
+	sender     *sender
+	recvWindow *receiver
+	// Frames sent here have only been handed to the Muxer; the Muxer sender
+	// performs and publishes completion of the actual transport write.
 	sendQueue         chan []byte
 	prioritySendQueue chan []byte
 	// +checklocks:l
@@ -51,9 +53,14 @@ type Reliable struct {
 	lastFrameSent atomic.Uint32
 	unsend        uint16
 
-	closed   chan struct{}
+	// closed publishes completion of the lifecycle transition and sender drain.
+	closed chan struct{}
+	// initRecv publishes receipt of the peer's initiation frame.
 	initRecv chan struct{}
+	// initDone publishes termination of the initiation producer.
 	initDone chan struct{}
+	// sendDone publishes that all inner sender frames were handed to the Muxer.
+	// It does not mean that the Muxer wrote those frames to the transport.
 	sendDone chan struct{}
 	l        sync.Mutex
 	log      *logrus.Entry
@@ -86,8 +93,15 @@ func (r *Reliable) initiate(req bool) {
 			},
 		}
 		ticker := time.NewTicker(initialRTT)
+		defer ticker.Stop()
 		for notInit {
+			r.l.Lock()
+			if r.tubeState != created {
+				r.l.Unlock()
+				return
+			}
 			r.sendQueue <- p.toBytes()
+			r.l.Unlock()
 			select {
 			case <-ticker.C:
 				r.log.Info("init rto exceeded")
@@ -101,7 +115,11 @@ func (r *Reliable) initiate(req bool) {
 			}
 		}
 	} else {
-		<-r.initRecv
+		select {
+		case <-r.initRecv:
+		case <-r.closed:
+			return
+		}
 	}
 
 	go r.send()
@@ -152,7 +170,7 @@ func (r *Reliable) sendOneFrame(pkt *frame, retransmission bool) {
 			"ack":     pkt.flags.ACK,
 			"fin":     pkt.flags.FIN,
 			"dataLen": pkt.dataLength,
-		}).Trace("sent packet")
+		}).Trace("handed packet to muxer")
 	}
 }
 
@@ -176,7 +194,8 @@ func (r *Reliable) sendRetransmissionAck(lastFrameNo, ackNo uint32, tubeId byte)
 	r.prioritySendQueue <- rtrPkt.toBytes()
 }
 
-// send continuously reads packet from the sends and hands them to the muxer
+// send drains the Reliable sender queues into the Muxer queues. Closing
+// sendDone means every frame was handed off, not written to the transport.
 func (r *Reliable) send() {
 	var pkt *frame
 	sendQueue := r.sender.sendQueue                 // +checklocksignore accessing channels is safe
@@ -187,6 +206,10 @@ func (r *Reliable) send() {
 		case <-r.sender.RetransmitTicker.C: // +checklocksignore accessing channels is safe
 
 			r.l.Lock()
+			if r.sender.closed.Load() {
+				r.l.Unlock()
+				continue
+			}
 
 			numFrames := r.sender.framesToSend(true, 0)
 
@@ -254,6 +277,10 @@ func (r *Reliable) send() {
 
 		case <-r.sender.senderWindow.windowOpen: // +checklocksignore accessing channels is safe
 			r.l.Lock()
+			if r.sender.closed.Load() {
+				r.l.Unlock()
+				continue
+			}
 			numFrames := r.sender.framesToSend(false, 0)
 			r.log.WithField("numFrames", numFrames).Trace("window open")
 
@@ -271,7 +298,7 @@ func (r *Reliable) send() {
 					windowFrame.Time = time.Now()
 					windowFrame.queued = true
 
-					safeSend(r.sender.sendQueue, windowFrame.frame)
+					r.sender.sendQueue <- windowFrame.frame
 
 					r.sender.unacked++
 
@@ -302,18 +329,6 @@ func (r *Reliable) send() {
 	}
 	r.log.Debug("send ended")
 	close(r.sendDone)
-}
-
-// safeSend prevent to send a frame on a closed channel
-func safeSend(ch chan *frame, value *frame) (closed bool) {
-	defer func() {
-		if recover() != nil {
-			closed = true
-		}
-	}()
-
-	ch <- value
-	return false
 }
 
 // receive is called by the muxer for each new packet
@@ -352,7 +367,11 @@ func (r *Reliable) receive(pkt *frame) error {
 
 	// Pass the frame to the sender
 	if pkt.flags.ACK {
-		missingFrameNo, _ := r.sender.recvAck(pkt.ackNo)
+		missingFrameNo, ackErr := r.sender.recvAck(pkt.ackNo)
+		if ackErr != nil {
+			r.enterClosedState()
+			return ackErr
+		}
 		if missingFrameNo != 0 {
 			r.sender.m.Lock()
 			r.sendFrameByNumberLocked(missingFrameNo)
@@ -419,18 +438,21 @@ func (r *Reliable) enterClosedState() {
 	if r.tubeState == closed {
 		return
 	}
+	previousState := r.tubeState
+	// Reject every producer before closing sender queues. This remains visible
+	// while the lifecycle lock is released to wait for the sender to drain.
+	r.tubeState = closed
 	if r.lastAckTimer != nil {
 		r.lastAckTimer.Stop()
 	}
 	r.sender.Close()
 	r.recvWindow.Close()
-	if r.tubeState != created {
+	if previousState != created {
 		r.l.Unlock()
 		<-r.sendDone
 		r.l.Lock()
 	}
 	close(r.closed)
-	r.tubeState = closed
 }
 
 func (r *Reliable) receiveInitiatePkt(pkt *initiateFrame) error {
@@ -454,7 +476,10 @@ func (r *Reliable) receiveInitiatePkt(pkt *initiateFrame) error {
 		r.recvWindow.m.Unlock()
 		r.log.Debug("INITIATED!")
 		r.tubeState = initiated
-		r.sender.recvAck(1)
+		if _, err := r.sender.recvAck(1); err != nil {
+			r.enterClosedState()
+			return err
+		}
 		close(r.initRecv)
 	}
 
@@ -493,7 +518,8 @@ func (r *Reliable) Read(b []byte) (n int, err error) {
 	return r.recvWindow.read(b)
 }
 
-// Write satisfies the net.Conn interface
+// Write queues b in the Reliable sender. It can return before the frame is
+// handed to the Muxer or written to the underlying transport.
 func (r *Reliable) Write(b []byte) (n int, err error) {
 	<-r.initDone
 	r.l.Lock()
@@ -538,7 +564,9 @@ func (r *Reliable) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPA
 	return n, 0, 0, nil, e
 }
 
-// Close handles closing reliable tubes
+// Close initiates the Reliable FIN state machine after admitting the FIN to the
+// local sender. It does not wait for sender drain or peer acknowledgement; use
+// WaitForClose for lifecycle completion.
 func (r *Reliable) Close() (err error) {
 	select {
 	case <-r.initDone:

--- a/tubes/reliable.go
+++ b/tubes/reliable.go
@@ -75,7 +75,6 @@ var _ Tube = &Reliable{}
 // req: whether the tube is requesting to initiate a tube (true), or whether is respondding to an initiation request (false).
 func (r *Reliable) initiate(req bool) {
 	defer close(r.initDone)
-	notInit := true
 
 	if req {
 		p := initiateFrame{
@@ -94,22 +93,25 @@ func (r *Reliable) initiate(req bool) {
 		}
 		ticker := time.NewTicker(initialRTT)
 		defer ticker.Stop()
-		for notInit {
+	initLoop:
+		for {
 			r.l.Lock()
-			if r.tubeState != created {
+			switch r.tubeState {
+			case initiated:
+				r.l.Unlock()
+				break initLoop
+			case created:
+				r.sendQueue <- p.toBytes()
+				r.l.Unlock()
+			default:
 				r.l.Unlock()
 				return
 			}
-			r.sendQueue <- p.toBytes()
-			r.l.Unlock()
+
 			select {
 			case <-ticker.C:
 				r.log.Info("init rto exceeded")
-				continue
 			case <-r.initRecv:
-				r.l.Lock()
-				notInit = r.tubeState == created
-				r.l.Unlock()
 			case <-r.closed:
 				return
 			}
@@ -122,10 +124,13 @@ func (r *Reliable) initiate(req bool) {
 		}
 	}
 
-	go r.send()
-
-	r.l.Lock() // required for checklocks
+	r.l.Lock()
+	if r.tubeState != initiated {
+		r.l.Unlock()
+		return
+	}
 	r.sender.closed.Store(false)
+	go r.send()
 	r.l.Unlock()
 }
 
@@ -438,16 +443,15 @@ func (r *Reliable) enterClosedState() {
 	if r.tubeState == closed {
 		return
 	}
-	previousState := r.tubeState
 	// Reject every producer before closing sender queues. This remains visible
 	// while the lifecycle lock is released to wait for the sender to drain.
 	r.tubeState = closed
 	if r.lastAckTimer != nil {
 		r.lastAckTimer.Stop()
 	}
-	r.sender.Close()
+	waitForSender := r.sender.Close() == nil
 	r.recvWindow.Close()
-	if previousState != created {
+	if waitForSender {
 		r.l.Unlock()
 		<-r.sendDone
 		r.l.Lock()

--- a/tubes/reliable.go
+++ b/tubes/reliable.go
@@ -180,8 +180,9 @@ func (r *Reliable) sendRetransmissionAck(lastFrameNo, ackNo uint32, tubeId byte)
 // send continuously reads packet from the sends and hands them to the muxer
 func (r *Reliable) send() {
 	var pkt *frame
-	ok := true
-	for ok {
+	sendQueue := r.sender.sendQueue                 // +checklocksignore accessing channels is safe
+	prioritySendQueue := r.sender.prioritySendQueue // +checklocksignore accessing channels is safe
+	for sendQueue != nil || prioritySendQueue != nil {
 		select {
 		// onTimeout sender
 		case <-r.sender.RetransmitTicker.C: // +checklocksignore accessing channels is safe
@@ -280,19 +281,23 @@ func (r *Reliable) send() {
 			}
 			r.l.Unlock()
 
-		case pkt, ok = <-r.sender.sendQueue: // +checklocksignore accessing channels is safe
+		case queuedPkt, ok := <-sendQueue: // +checklocksignore accessing channels is safe
 			if !ok {
-				break
+				sendQueue = nil
+				continue
 			}
 
 			// Do not block ACKs - Blocks frame transmission out of window open
+			pkt = queuedPkt
 			r.sendOneFrame(pkt, false)
 
-		case pkt, ok = <-r.sender.prioritySendQueue: // +checklocksignore accessing channels is safe
+		case queuedPkt, ok := <-prioritySendQueue: // +checklocksignore accessing channels is safe
 			if !ok {
-				break
+				prioritySendQueue = nil
+				continue
 			}
 
+			pkt = queuedPkt
 			r.sendOneFrame(pkt, true)
 		}
 	}

--- a/tubes/reliable.go
+++ b/tubes/reliable.go
@@ -1,4 +1,3 @@
-// Package tubes implements the multiplexing of raw data into logical channels of a hop session
 package tubes
 
 import (

--- a/tubes/sender.go
+++ b/tubes/sender.go
@@ -378,6 +378,7 @@ func (s *sender) framesToSend(rto bool, startIndex int) int {
 // Close stops the sender and causes future writes to return io.EOF
 func (s *sender) Close() error {
 	if s.closed.CompareAndSwap(false, true) {
+		s.RetransmitTicker.Stop()
 		close(s.sendQueue)
 		close(s.prioritySendQueue)
 

--- a/tubes/sender.go
+++ b/tubes/sender.go
@@ -58,6 +58,8 @@ type sender struct {
 	// the time after which writes will expire
 	deadline time.Time
 
+	// sendQueue and prioritySendQueue contain frames admitted by the reliable
+	// state machine but not necessarily handed to the Muxer or transport.
 	sendQueue         chan *frame
 	prioritySendQueue chan *frame
 
@@ -184,9 +186,8 @@ func (s *sender) recvAck(ackNo uint32) (uint32, error) {
 	}
 
 	if s.senderWindow.duplicatedAckCounter > 100 {
-		// TODO (paul): make sure that this is the right way to terminate a connection
-		// Should not happen
-		s.Close()
+		// The Reliable owns lifecycle transitions and sender queue closure.
+		return 0, errTooManyDuplicateACKs
 	}
 
 	// to not apply on the first 20 ACKs as the network probing is inaccurate
@@ -375,7 +376,8 @@ func (s *sender) framesToSend(rto bool, startIndex int) int {
 	return numFrames
 }
 
-// Close stops the sender and causes future writes to return io.EOF
+// Close stops the sender and causes future writes to return io.EOF. Only the
+// owning Reliable's close transition may call it, after rejecting producers.
 func (s *sender) Close() error {
 	if s.closed.CompareAndSwap(false, true) {
 		s.RetransmitTicker.Stop()

--- a/tubes/state_machine_test.go
+++ b/tubes/state_machine_test.go
@@ -1,6 +1,12 @@
 package tubes
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/sirupsen/logrus"
+
+	"gotest.tools/assert"
+)
 
 /*
 Below is a high-level summary of the TCP-like state machine in tubes/reliable.go
@@ -204,6 +210,53 @@ func TestActiveClose(t *testing.T) {
 // Responder: handle peer FIN similarly
 func TestSimultaneousClose(t *testing.T) {
 	// TODO(dadrian)[2025-08-02]: Implement this test.
+}
+
+// TestFinalFINAckIsSentBeforeClose verifies that entering the closed state
+// cannot discard the ACK queued for the peer's FIN. The peer cannot leave
+// lastAck until it receives this packet.
+func TestFinalFINAckIsSentBeforeClose(t *testing.T) {
+	const attempts = 128
+	for range attempts {
+		log := logrus.New().WithField("test", t.Name())
+		s := newSender(log)
+		s.closed.Store(false)
+
+		initDone := make(chan struct{})
+		close(initDone)
+		r := &Reliable{
+			id:                1,
+			sender:            s,
+			recvWindow:        newReceiver(log),
+			sendQueue:         make(chan []byte, 1),
+			prioritySendQueue: make(chan []byte, 1),
+			tubeState:         finWait2,
+			closed:            make(chan struct{}),
+			initRecv:          make(chan struct{}),
+			initDone:          initDone,
+			sendDone:          make(chan struct{}),
+			log:               log,
+		}
+		go r.send()
+
+		err := r.receive(&frame{
+			frameNo: 1,
+			flags: frameFlags{
+				FIN: true,
+			},
+		})
+		assert.NilError(t, err)
+
+		select {
+		case raw := <-r.sendQueue:
+			pkt, err := fromBytes(raw)
+			assert.NilError(t, err)
+			assert.Check(t, pkt.flags.ACK)
+			assert.Equal(t, pkt.ackNo, uint32(1))
+		default:
+			t.Fatal("final FIN ACK was discarded while stopping the sender")
+		}
+	}
 }
 
 // TestMissingFINACKLastAckTimeout tests:

--- a/tubes/unreliable.go
+++ b/tubes/unreliable.go
@@ -102,19 +102,24 @@ func (u *Unreliable) initiate(req bool) {
 
 	// RESP init frames are generated in receiveInitiatePkt
 	if req {
-		notInit := true
 		ticker := time.NewTicker(initialRTT)
 		defer ticker.Stop()
-		for notInit {
+	initLoop:
+		for {
 			u.lifecycleMu.Lock()
-			if u.state.Load() != created {
+			switch u.state.Load() {
+			case initiated:
+				u.lifecycleMu.Unlock()
+				break initLoop
+			case created:
+				p := u.makeInitFrame(req)
+				u.sendQueue <- p.toBytes()
+				u.lifecycleMu.Unlock()
+			default:
 				u.lifecycleMu.Unlock()
 				close(u.senderDone)
 				return
 			}
-			p := u.makeInitFrame(req)
-			u.sendQueue <- p.toBytes()
-			u.lifecycleMu.Unlock()
 
 			select {
 			case <-ticker.C:
@@ -124,7 +129,6 @@ func (u *Unreliable) initiate(req bool) {
 				close(u.senderDone)
 				return
 			}
-			notInit = u.state.Load() == created
 		}
 	}
 

--- a/tubes/unreliable.go
+++ b/tubes/unreliable.go
@@ -1,4 +1,3 @@
-// Package tubes implements the multiplexing of raw data into logical channels of a hop session
 package tubes
 
 import (

--- a/tubes/unreliable.go
+++ b/tubes/unreliable.go
@@ -3,6 +3,7 @@ package tubes
 import (
 	"io"
 	"net"
+	"sync"
 	"sync/atomic"
 	"time"
 
@@ -14,24 +15,39 @@ import (
 
 // Unreliable implements UDP-like messages for Hop
 type Unreliable struct {
-	tType     TubeType
-	id        byte
+	tType TubeType
+	id    byte
+	// sendQueue hands encoded frames to the Muxer. A completed send does not
+	// imply that the frame has been written to the underlying transport.
 	sendQueue chan []byte
 
 	// Unreliable tubes can be in three states:
 	// created: Indicates the tube has been created and is waiting for the remote peer send back an initiate frame
 	// initiated: Indicates the tube is ready to read and write data
 	// closed: Indicates the tube is done reading and writing data
-	state        atomic.Value
-	initiated    chan struct{}
+	state atomic.Value
+	// lifecycleMu orders Close with initiation and packet admission. Producers
+	// recheck state while holding it, so FIN is last and late receives are
+	// rejected; Close separately joins the sender before publishing completion.
+	lifecycleMu sync.Mutex
+	// initiated publishes receipt of the peer's initiation frame.
+	initiated chan struct{}
+	// initiateDone publishes termination of the initiation producer.
 	initiateDone chan struct{}
-	senderDone   chan struct{}
-	closed       chan struct{}
+	// stopInitiate stops a locally initiated handshake without publishing Close
+	// completion early.
+	stopInitiate chan struct{}
+	// senderDone publishes that every queued frame was handed to the Muxer.
+	senderDone chan struct{}
+	// closed publishes completion of Close, including the sender drain.
+	closed chan struct{}
 
+	// recv contains frames accepted from the Muxer but not returned to a reader.
 	recv *common.DeadlineChan[[]byte]
+	// send contains messages accepted from writers but not handed to the Muxer.
 	send *common.DeadlineChan[[]byte]
 
-	frameNo atomic.Uint32
+	frameNo atomic.Uint32 // +checklocks:lifecycleMu
 
 	localAddr  net.Addr
 	remoteAddr net.Addr
@@ -51,9 +67,11 @@ var _ transport.MsgConn = &Unreliable{}
 // Unreliable tubes are tubes
 var _ Tube = &Unreliable{}
 
+// sender drains the local queue into the Muxer queue. senderDone only means the
+// frames were handed off; the Muxer sender owns actual transport writes.
 func (u *Unreliable) sender() {
 	for b := range u.send.C {
-		u.log.Trace("sending packet")
+		u.log.Trace("handing packet to muxer")
 		u.sendQueue <- b
 	}
 
@@ -86,15 +104,23 @@ func (u *Unreliable) initiate(req bool) {
 	if req {
 		notInit := true
 		ticker := time.NewTicker(initialRTT)
+		defer ticker.Stop()
 		for notInit {
+			u.lifecycleMu.Lock()
+			if u.state.Load() != created {
+				u.lifecycleMu.Unlock()
+				close(u.senderDone)
+				return
+			}
 			p := u.makeInitFrame(req)
 			u.sendQueue <- p.toBytes()
+			u.lifecycleMu.Unlock()
 
 			select {
 			case <-ticker.C:
 				u.log.Info("init rto exceeded")
 			case <-u.initiated:
-			case <-u.closed:
+			case <-u.stopInitiate:
 				close(u.senderDone)
 				return
 			}
@@ -122,8 +148,10 @@ func (u *Unreliable) receiveInitiatePkt(pkt *initiateFrame) error {
 	}
 
 	// Send a RESP packet in response to REQ packets
+	u.lifecycleMu.Lock()
+	defer u.lifecycleMu.Unlock()
 	if pkt.flags.REQ && u.state.Load() != closed {
-		u.log.Trace("sending RESP packet")
+		u.log.Trace("handing RESP packet to muxer")
 		p := u.makeInitFrame(false)
 		u.sendQueue <- p.toBytes()
 	}
@@ -132,6 +160,12 @@ func (u *Unreliable) receiveInitiatePkt(pkt *initiateFrame) error {
 }
 
 func (u *Unreliable) receive(pkt *frame) error {
+	u.lifecycleMu.Lock()
+	defer u.lifecycleMu.Unlock()
+	if u.state.Load() == closed {
+		return ErrBadTubeState
+	}
+
 	select {
 	case u.recv.C <- pkt.data:
 	default:
@@ -187,8 +221,9 @@ func (u *Unreliable) WriteMsg(b []byte) (err error) {
 	return
 }
 
-// WriteMsgUDP implements implements the UDPLike interface
-// oob and addr are ignored
+// WriteMsgUDP queues one message for the Unreliable sender. It may return before
+// the message is handed to the Muxer or written to the transport. oob and addr
+// are ignored.
 func (u *Unreliable) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int, err error) {
 	select {
 	case <-u.initiated:
@@ -196,6 +231,13 @@ func (u *Unreliable) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int,
 	case <-u.closed:
 		break
 	}
+
+	u.lifecycleMu.Lock()
+	defer u.lifecycleMu.Unlock()
+	if u.state.Load() == closed {
+		return 0, 0, io.EOF
+	}
+
 	dataLength := uint16(len(b))
 	if uint16(len(b)) > MaxFrameDataLength {
 		err = transport.ErrBufOverflow
@@ -227,35 +269,50 @@ func (u *Unreliable) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int,
 	u.log.WithFields(logrus.Fields{
 		"frameNo":    pkt.frameNo,
 		"dataLength": pkt.dataLength,
-	}).Trace("wrote packet")
+	}).Trace("queued packet")
 	return n, 0, err
 }
 
-// Close implements the net.Conn interface. Future io operations will return io.EOF
+// Close rejects new packets, places FIN after accepted writes, and waits until
+// the sender hands its queue to the Muxer. It does not wait for transport writes
+// or peer receipt. Future operations return io.EOF after buffered reads drain.
 func (u *Unreliable) Close() error {
+	u.lifecycleMu.Lock()
 	oldState := u.state.Swap(closed)
 	if oldState == closed {
+		u.lifecycleMu.Unlock()
 		return io.EOF
 	}
+	u.lifecycleMu.Unlock()
 
-	pkt := frame{
-		tubeID: u.id,
-		flags: frameFlags{
-			ACK:  false,
-			FIN:  true,
-			REQ:  false,
-			RESP: false,
-			REL:  false,
-		},
-
-		dataLength: 0,
-		frameNo:    u.frameNo.Load(),
-		data:       []byte{},
-		queued:     false,
+	if oldState == created {
+		close(u.stopInitiate)
 	}
-	u.frameNo.Add(1)
+	<-u.initiateDone
 
-	err := u.send.Send(pkt.toBytes())
+	u.lifecycleMu.Lock()
+	defer u.lifecycleMu.Unlock()
+
+	var err error
+	if oldState == initiated {
+		pkt := frame{
+			tubeID: u.id,
+			flags: frameFlags{
+				ACK:  false,
+				FIN:  true,
+				REQ:  false,
+				RESP: false,
+				REL:  false,
+			},
+
+			dataLength: 0,
+			frameNo:    u.frameNo.Load(),
+			data:       []byte{},
+			queued:     false,
+		}
+		u.frameNo.Add(1)
+		err = u.send.Send(pkt.toBytes())
+	}
 
 	u.send.Close()
 	u.recv.Close()


### PR DESCRIPTION
## Summary

- replace `WaitGroup`-based lifecycle signals with one-shot completion channels
- make `Client.Close` interrupt in-progress handshakes and synchronize `Server.Serve`/`Close` startup
- serialize session writes while avoiding session locks across blocking socket I/O
- make session shutdown deterministic and safely discard late packets
- drain both reliable-tube sender queues during shutdown so the final FIN ACK cannot be discarded
- add invariant, race, and deadlock coverage for transport lifecycle operations and reliable-tube teardown

## Why

The transport lifecycle used `WaitGroup` values both for worker accounting and one-shot signaling. Concurrent `Close`, handshake, and `Serve` startup could race with `Add`/`Wait`, panic, return before shutdown completed, or deadlock while a lock was held across blocking network I/O.

Presubmit also exposed a tubes shutdown race: a reliable tube closed both internal sender queues, but its sender loop exited as soon as either closed queue was selected. The final ACK for a peer FIN could remain queued and never reach the transport, leaving the peer in `lastAck` until its one-second muxer deadline expired.

These changes give each transport lifecycle transition a single owner, publish completion through closed channels, interrupt underlying I/O before waiting for workers, and drain both tube sender queues before the sender terminates.

## Impact

`Close` is now idempotent and safe under concurrent calls, handshakes and accepts reliably unblock during shutdown, session writes preserve counter/order invariants, and tube teardown reliably completes without spurious connection timeouts.

## Validation

- `make format`
- `make build`
- `make lint`
- `make vet`
- `make test`
- `go test -race -count=10 -timeout 120s ./transport`
- `go test -race -count=10 -timeout 180s ./tubes`
- `go test -run '^TestSelfAuthGrant$' -count=100 -timeout=120s ./hoptests`
- `go test -race -run '^TestSelfAuthGrant$' -count=50 -timeout=120s ./hoptests`
- `go test -race -run '^TestFinalFINAckIsSentBeforeClose$' -count=100 ./tubes`

## Codex session summary

This PR was developed through an extended concurrency audit spanning `transport` and `tubes`.

### Work completed

- Audited `Client`, `Server`, `Handle`, and `SessionState` lifecycle ownership, publication, wait-group registration, read/write serialization, and close ordering.
- Replaced ambiguous one-value lifecycle channels with close-only broadcast channels and documented why closed-channel receives are repeatable and non-blocking.
- Added invariant-focused transport concurrency tests and comments stating the contract each test protects.
- Rebased the branch onto current `main`, pushed the updated branch, and kept PR #195 current throughout the session.
- Diagnosed presubmit flakes in the tubes layer rather than treating them as unrelated test failures.
- Fixed reliable sender shutdown so both internal queues drain and final FIN acknowledgements reach the muxer.
- Fixed the outer muxer shutdown race where a tube handoff was mistaken for a completed transport write.
- Added a bounded forced-close path so a blocked transport write cannot deadlock upstream reliable or unreliable producers.
- Made the `Reliable` lifecycle the sole owner of sender-queue closure, published `closed` before releasing its lifecycle lock, stopped responder-init goroutines during forced close, and prevented pending retransmission work after closure.
- Ordered unreliable initiation, writes, FIN, and late receives through its lifecycle lock so FIN remains last and no new receive data is admitted after close.
- Added Go package documentation in `transport/doc.go` and `tubes/doc.go` describing lock ordering, completion publication, queue ownership, and producer-to-consumer shutdown.
- Audited comments so `queued`, `handed to the muxer`, `accepted by the configured transport`, and `received by the peer` are not conflated.
- Added `make test-concurrency`, which runs race-enabled, shuffled tests for `transport`, `tubes`, and `hoptests` under `GOMAXPROCS=1,2,4`; `CONCURRENCY_TEST_COUNT` controls repetition and defaults to 10.
- Repeated the previously flaky agent-auth test 100 times and verified build, lint, checklocks, the full race suite, and GitHub Presubmit.

### User prompts

<details>
<summary>Chronological task prompt history (17 prompts)</summary>

1. “Audit the concurrency model in transport/. Add tests as needed to ensure that it works. In particular, make sure there are no race conditions in Close(), and that it can't deadlock. Ensure there are tests for every invariant that the concurrency model expectgs / attempts to uphold.”

2. “Commit this to a branch, dadrian/transparency-concurrency-fixes-codex and create a PR”

3. “Fetch main, then rebase this branch onto main and update the PR (push remote)”

4. “Keep going and also fix the failures in the presubmit tests (which are likely also flakely concurrency failures, possibly in the tubes layer). If the failures aren't do to a root cause in tubes or transport, let me know and ask what to do next.”

5. “In transport/client.go, line 94 of the new code, what happens if <-c.handshakeDone gets called on a closed channel, or called more than once? Only one value is ever written.”

6. “In what situation would line 81 occur?”

7. “In what case is the if statement _true_ at line 81?”

8. “Why isn't c.err = err inside the if body?”

9. “Add a comment before line 80 explaining 80 and 81, and a comment before line 88, explaining 88 and 89. Each should be brief, ~one line. It should prevent the conversation we just had from needing to take place.”

10. “Make sure all tests in concurrency_test.go have comments explaining what invariant they're testing. It looks like most, but not all, do.”

11. “In handle.go, why don't we need c.recv.Close() anymore in Close(), line 193-ish”

12. “What file has sessionState.closeLocked()?”

13. “Find somewhere to document the concurrency patterns now leveraged by transport and tubes, ideally in a Go file and not Markdown. There might already be some of this in tests or in package-level or struct-level comments.”

14. “Also fix whatever the test failure was in the last GH action run: https://github.com/hop-proto/hop-go/actions/runs/30228099346/job/89861738146?pr=195”

15. “Why was this issue getting caught on actions but not here? What can we do to prevent that in the future, beyond the tests you just added?”

16. “Add a make target for (1), and then audit comments according to (3). Audit the code for (5) within tubes and transport.”

17. “Update the PR description to have a section that summarizes this codex session, including all my prompts.”

</details>

The repository-guidance prompt additionally supplied the `/home/sprite/hop-go` `AGENTS.md` requirements: use the Sprite workflow, avoid Docker, run `make format`, and ensure build, lint, and test gates pass.