### PR TITLE
Check Hop certificate expiration

### DIFF
--- a/certs/issue.go
+++ b/certs/issue.go
@@ -26,12 +26,22 @@ func issue(parent *Certificate, child *Identity, certType CertificateType, durat
 	if parent.privateKey == nil {
 		return nil, errors.New("issue requires a private key")
 	}
+	if duration <= 0 {
+		return nil, errors.New("issue requires a positive duration")
+	}
 	now := time.Now()
+	if now.Before(parent.IssuedAt) || !now.Before(parent.ExpiresAt) {
+		return nil, errors.New("issue requires a currently valid parent")
+	}
+	expiresAt := now.Add(duration)
+	if expiresAt.After(parent.ExpiresAt) {
+		expiresAt = parent.ExpiresAt
+	}
 	out := &Certificate{
 		Version:   Version,
 		Type:      certType,
-		IssuedAt:  time.Now(),
-		ExpiresAt: now.Add(week),
+		IssuedAt:  now,
+		ExpiresAt: expiresAt,
 		IDChunk: IDChunk{
 			Blocks: child.Names,
 		},
@@ -80,10 +90,16 @@ func issue(parent *Certificate, child *Identity, certType CertificateType, durat
 // TODO(dadrian): Should we just use XEdDSA so that we don't need to have two
 // different key types, in exchange for having to implement more cryptography?
 func IssueLeaf(parent *Certificate, child *Identity) (*Certificate, error) {
+	return IssueLeafWithValidity(parent, child, week)
+}
+
+// IssueLeafWithValidity issues a leaf Certificate for the requested validity
+// period. The certificate will never outlive its intermediate parent.
+func IssueLeafWithValidity(parent *Certificate, child *Identity, validity time.Duration) (*Certificate, error) {
 	if parent.Type != Intermediate {
 		return nil, errors.New("IssueLeaf requires the parent to be an intermediate")
 	}
-	return issue(parent, child, Leaf, week)
+	return issue(parent, child, Leaf, validity)
 }
 
 func selfSign(self *Identity, certificateType CertificateType, keyPair *keys.SigningKeyPair) (*Certificate, error) {

--- a/certs/issue.go
+++ b/certs/issue.go
@@ -18,8 +18,8 @@ const (
 	week = time.Hour * 7 * 24
 )
 
-// issue does the heavy lifting of issuing and signing
-func issue(parent *Certificate, child *Identity, certType CertificateType, duration time.Duration) (*Certificate, error) {
+// issue does the heavy lifting of issuing and signing.
+func issue(parent *Certificate, child *Identity, certType CertificateType, issuedAt time.Time, duration time.Duration) (*Certificate, error) {
 	if parent.Fingerprint == zero {
 		return nil, errors.New("issue requires SHA3Fingerprint to be set")
 	}
@@ -29,18 +29,17 @@ func issue(parent *Certificate, child *Identity, certType CertificateType, durat
 	if duration <= 0 {
 		return nil, errors.New("issue requires a positive duration")
 	}
-	now := time.Now()
-	if now.Before(parent.IssuedAt) || !now.Before(parent.ExpiresAt) {
-		return nil, errors.New("issue requires a currently valid parent")
+	if issuedAt.Before(parent.IssuedAt) || !issuedAt.Before(parent.ExpiresAt) {
+		return nil, errors.New("issue requires the parent to be valid at issuance time")
 	}
-	expiresAt := now.Add(duration)
+	expiresAt := issuedAt.Add(duration)
 	if expiresAt.After(parent.ExpiresAt) {
 		expiresAt = parent.ExpiresAt
 	}
 	out := &Certificate{
 		Version:   Version,
 		Type:      certType,
-		IssuedAt:  now,
+		IssuedAt:  issuedAt,
 		ExpiresAt: expiresAt,
 		IDChunk: IDChunk{
 			Blocks: child.Names,
@@ -86,20 +85,24 @@ func issue(parent *Certificate, child *Identity, certType CertificateType, durat
 // key.
 //
 // TODO(dadrian): Do we need Authorization Indicator?
-//
-// TODO(dadrian): Should we just use XEdDSA so that we don't need to have two
-// different key types, in exchange for having to implement more cryptography?
 func IssueLeaf(parent *Certificate, child *Identity) (*Certificate, error) {
 	return IssueLeafWithValidity(parent, child, week)
 }
 
 // IssueLeafWithValidity issues a leaf Certificate for the requested validity
-// period. The certificate will never outlive its intermediate parent.
+// period at the current time. The certificate will never outlive its
+// intermediate parent.
 func IssueLeafWithValidity(parent *Certificate, child *Identity, validity time.Duration) (*Certificate, error) {
+	return IssueLeafAt(parent, child, time.Now(), validity)
+}
+
+// IssueLeafAt issues a leaf Certificate at issuedAt for the requested validity
+// period. The certificate will never outlive its intermediate parent.
+func IssueLeafAt(parent *Certificate, child *Identity, issuedAt time.Time, validity time.Duration) (*Certificate, error) {
 	if parent.Type != Intermediate {
 		return nil, errors.New("IssueLeaf requires the parent to be an intermediate")
 	}
-	return issue(parent, child, Leaf, validity)
+	return issue(parent, child, Leaf, issuedAt, validity)
 }
 
 func selfSign(self *Identity, certificateType CertificateType, keyPair *keys.SigningKeyPair) (*Certificate, error) {
@@ -166,7 +169,7 @@ func IssueIntermediate(root *Certificate, intermediate *Identity) (*Certificate,
 	if root.Type != Root {
 		return nil, errors.New("IssueIntermediate requires the parent to be a root")
 	}
-	return issue(root, intermediate, Intermediate, time.Hour*24*366)
+	return issue(root, intermediate, Intermediate, time.Now(), time.Hour*24*366)
 }
 
 // SelfSignLeaf issues self-signed leaf certificate using only a key.

--- a/certs/issue_test.go
+++ b/certs/issue_test.go
@@ -38,7 +38,7 @@ func TestIssueSelfSigned(t *testing.T) {
 	}
 }
 
-func TestIssueLeafWithValidity(t *testing.T) {
+func TestIssueLeafAt(t *testing.T) {
 	rootKey := keys.GenerateNewSigningKeyPair()
 	root, err := SelfSignRoot(SigningIdentity(rootKey), rootKey)
 	assert.NilError(t, err)
@@ -50,13 +50,39 @@ func TestIssueLeafWithValidity(t *testing.T) {
 	assert.NilError(t, intermediate.ProvideKey((*[32]byte)(&intermediateKey.Private)))
 
 	leafKey := keys.GenerateNewX25519KeyPair()
-	leaf, err := IssueLeafWithValidity(intermediate, LeafIdentity(leafKey, RawStringName("short-lived")), time.Hour)
+	issuedAt := intermediate.IssuedAt
+	leaf, err := IssueLeafAt(
+		intermediate,
+		LeafIdentity(leafKey, RawStringName("short-lived")),
+		issuedAt,
+		time.Hour,
+	)
 	assert.NilError(t, err)
-	assert.Check(t, leaf.ExpiresAt.Sub(leaf.IssuedAt) >= time.Hour-time.Second)
-	assert.Check(t, leaf.ExpiresAt.Sub(leaf.IssuedAt) <= time.Hour+time.Second)
+	assert.Equal(t, leaf.IssuedAt, issuedAt)
+	assert.Equal(t, leaf.ExpiresAt, issuedAt.Add(time.Hour))
 	assert.NilError(t, VerifyParent(leaf, intermediate))
 
-	intermediate.ExpiresAt = time.Now().Add(-time.Second)
-	_, err = IssueLeafWithValidity(intermediate, LeafIdentity(leafKey), time.Hour)
-	assert.ErrorContains(t, err, "currently valid parent")
+	_, err = IssueLeafAt(intermediate, LeafIdentity(leafKey), intermediate.ExpiresAt, time.Hour)
+	assert.ErrorContains(t, err, "valid at issuance time")
+}
+
+func TestIssueLeafWithValidityUsesCurrentTime(t *testing.T) {
+	rootKey := keys.GenerateNewSigningKeyPair()
+	root, err := SelfSignRoot(SigningIdentity(rootKey), rootKey)
+	assert.NilError(t, err)
+	assert.NilError(t, root.ProvideKey((*[32]byte)(&rootKey.Private)))
+
+	intermediateKey := keys.GenerateNewSigningKeyPair()
+	intermediate, err := IssueIntermediate(root, SigningIdentity(intermediateKey))
+	assert.NilError(t, err)
+	assert.NilError(t, intermediate.ProvideKey((*[32]byte)(&intermediateKey.Private)))
+
+	before := time.Now()
+	leafKey := keys.GenerateNewX25519KeyPair()
+	leaf, err := IssueLeafWithValidity(intermediate, LeafIdentity(leafKey), time.Hour)
+	after := time.Now()
+	assert.NilError(t, err)
+	assert.Check(t, !leaf.IssuedAt.Before(before))
+	assert.Check(t, !leaf.IssuedAt.After(after))
+	assert.Equal(t, leaf.ExpiresAt, leaf.IssuedAt.Add(time.Hour))
 }

--- a/certs/issue_test.go
+++ b/certs/issue_test.go
@@ -2,6 +2,7 @@ package certs
 
 import (
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 	"gotest.tools/assert/cmp"
@@ -35,4 +36,27 @@ func TestIssueSelfSigned(t *testing.T) {
 		assert.Check(t, cmp.DeepEqual(c.PublicKey[:], k.Public[:]), i)
 		assert.Check(t, cmp.DeepEqual(c.IDChunk.Blocks, identities[i].Names), i)
 	}
+}
+
+func TestIssueLeafWithValidity(t *testing.T) {
+	rootKey := keys.GenerateNewSigningKeyPair()
+	root, err := SelfSignRoot(SigningIdentity(rootKey), rootKey)
+	assert.NilError(t, err)
+	assert.NilError(t, root.ProvideKey((*[32]byte)(&rootKey.Private)))
+
+	intermediateKey := keys.GenerateNewSigningKeyPair()
+	intermediate, err := IssueIntermediate(root, SigningIdentity(intermediateKey))
+	assert.NilError(t, err)
+	assert.NilError(t, intermediate.ProvideKey((*[32]byte)(&intermediateKey.Private)))
+
+	leafKey := keys.GenerateNewX25519KeyPair()
+	leaf, err := IssueLeafWithValidity(intermediate, LeafIdentity(leafKey, RawStringName("short-lived")), time.Hour)
+	assert.NilError(t, err)
+	assert.Check(t, leaf.ExpiresAt.Sub(leaf.IssuedAt) >= time.Hour-time.Second)
+	assert.Check(t, leaf.ExpiresAt.Sub(leaf.IssuedAt) <= time.Hour+time.Second)
+	assert.NilError(t, VerifyParent(leaf, intermediate))
+
+	intermediate.ExpiresAt = time.Now().Add(-time.Second)
+	_, err = IssueLeafWithValidity(intermediate, LeafIdentity(leafKey), time.Hour)
+	assert.ErrorContains(t, err, "currently valid parent")
 }

--- a/certs/verify.go
+++ b/certs/verify.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"time"
 
 	"hop.computer/hop/keys"
 )
@@ -126,6 +127,7 @@ const (
 	ReasonUnverifiedParent    VerificationFailureReason = iota
 	ReasonUnexpectedType      VerificationFailureReason = iota
 	ReasonInvalidCertificate  VerificationFailureReason = iota
+	ReasonTimeInvalid         VerificationFailureReason = iota
 	ReasonInternalError       VerificationFailureReason = iota
 )
 
@@ -144,6 +146,8 @@ func (r VerificationFailureReason) String() string {
 		return "unexpected certificate type"
 	case ReasonInvalidCertificate:
 		return "invalid certificate"
+	case ReasonTimeInvalid:
+		return "certificate is not currently valid"
 	case ReasonInternalError:
 		return "internal error"
 	default:
@@ -208,6 +212,20 @@ func mismatchedName(c *Certificate, target Name) error {
 	}
 }
 
+func timeInvalid(c *Certificate, now time.Time) error {
+	return &verifyError{
+		reason: ReasonTimeInvalid,
+		error: fmt.Errorf(
+			"%s: certificate %x is valid from %s until %s, current time is %s",
+			ReasonTimeInvalid,
+			c.Fingerprint,
+			c.IssuedAt,
+			c.ExpiresAt,
+			now,
+		),
+	}
+}
+
 // VerifyOptions holds parameters to VerifyLeaf.
 type VerifyOptions struct {
 	// PresentedIntermediate will be used to build a verified chain if it is
@@ -217,6 +235,10 @@ type VerifyOptions struct {
 
 	// Name is compared to the name on the leaf certificate if it is non-zero.
 	Name Name
+
+	// CurrentTime is used for validity checks. The current time is used when
+	// this field is zero.
+	CurrentTime time.Time
 }
 
 // VerifyLeaf verifies that the leaf chains up to a root in the store. It takes
@@ -231,6 +253,13 @@ func (s Store) VerifyLeaf(leaf *Certificate, opts VerifyOptions) error {
 	if !opts.Name.IsZero() && !leaf.MatchesName(opts.Name) {
 		return mismatchedName(leaf, opts.Name)
 	}
+	now := opts.CurrentTime
+	if now.IsZero() {
+		now = time.Now()
+	}
+	if now.Before(leaf.IssuedAt) || !now.Before(leaf.ExpiresAt) {
+		return timeInvalid(leaf, now)
+	}
 	var intermediate *Certificate
 	if opts.PresentedIntermediate != nil && leaf.Parent == opts.PresentedIntermediate.Fingerprint {
 		intermediate = opts.PresentedIntermediate
@@ -242,6 +271,9 @@ func (s Store) VerifyLeaf(leaf *Certificate, opts VerifyOptions) error {
 
 	if intermediate.Type != Intermediate {
 		return unexpectedTypeError(intermediate, Intermediate)
+	}
+	if now.Before(intermediate.IssuedAt) || !now.Before(intermediate.ExpiresAt) {
+		return timeInvalid(intermediate, now)
 	}
 	if intermediate.Fingerprint != leaf.Parent {
 		// Should not happen with a well-formed Store
@@ -257,6 +289,9 @@ func (s Store) VerifyLeaf(leaf *Certificate, opts VerifyOptions) error {
 	}
 	if root.Type != Root {
 		return unexpectedTypeError(root, Root)
+	}
+	if now.Before(root.IssuedAt) || !now.Before(root.ExpiresAt) {
+		return timeInvalid(root, now)
 	}
 	if root.Fingerprint != intermediate.Parent {
 		// Should not happen with a well-formed Store

--- a/certs/verify_test.go
+++ b/certs/verify_test.go
@@ -2,6 +2,7 @@ package certs
 
 import (
 	"testing"
+	"time"
 
 	"gotest.tools/assert"
 )
@@ -55,38 +56,60 @@ func TestVerifyLeaf(t *testing.T) {
 	assert.NilError(t, err)
 	leaf, err := ReadCertificatePEMFile("testdata/leaf.pem")
 	assert.NilError(t, err)
+	validTime := leaf.IssuedAt.Add(time.Second)
 
 	// Empty Storej
 	s := Store{}
 	err = s.VerifyLeaf(leaf, VerifyOptions{
 		PresentedIntermediate: intermediate,
+		CurrentTime:           validTime,
 	})
 	assert.ErrorContains(t, err, ReasonUnknownRoot.String())
 
 	// Only the root
 	s.AddCertificate(root)
 
-	err = s.VerifyLeaf(leaf, VerifyOptions{})
+	err = s.VerifyLeaf(leaf, VerifyOptions{CurrentTime: validTime})
 	assert.ErrorContains(t, err, ReasonUnknownIntermediate.String())
 	err = s.VerifyLeaf(leaf, VerifyOptions{
 		PresentedIntermediate: intermediate,
+		CurrentTime:           validTime,
 	})
 	assert.NilError(t, err)
 
 	// Add the intermediate
 	s.AddCertificate(intermediate)
-	err = s.VerifyLeaf(leaf, VerifyOptions{})
+	err = s.VerifyLeaf(leaf, VerifyOptions{CurrentTime: validTime})
 	assert.NilError(t, err)
 
 	// Name matching
 	err = s.VerifyLeaf(leaf, VerifyOptions{
-		Name: DNSName("domain.example"),
+		Name:        DNSName("domain.example"),
+		CurrentTime: validTime,
 	})
 	assert.NilError(t, err)
 	err = s.VerifyLeaf(leaf, VerifyOptions{
-		Name: DNSName("wrongdomain.example"),
+		Name:        DNSName("wrongdomain.example"),
+		CurrentTime: validTime,
 	})
 	assert.ErrorContains(t, err, ReasonMismatchedName.String())
+
+	err = s.VerifyLeaf(leaf, VerifyOptions{CurrentTime: leaf.IssuedAt.Add(-time.Second)})
+	assert.ErrorContains(t, err, ReasonTimeInvalid.String())
+	err = s.VerifyLeaf(leaf, VerifyOptions{CurrentTime: leaf.ExpiresAt})
+	assert.ErrorContains(t, err, ReasonTimeInvalid.String())
+
+	intermediateExpiry := intermediate.ExpiresAt
+	intermediate.ExpiresAt = validTime
+	err = s.VerifyLeaf(leaf, VerifyOptions{CurrentTime: validTime})
+	assert.ErrorContains(t, err, ReasonTimeInvalid.String())
+	intermediate.ExpiresAt = intermediateExpiry
+
+	rootExpiry := root.ExpiresAt
+	root.ExpiresAt = validTime
+	err = s.VerifyLeaf(leaf, VerifyOptions{CurrentTime: validTime})
+	assert.ErrorContains(t, err, ReasonTimeInvalid.String())
+	root.ExpiresAt = rootExpiry
 
 	// TODO(dadrian): Test all the error conditions
 }

--- a/transport/config.go
+++ b/transport/config.go
@@ -31,6 +31,11 @@ type VerifyConfig struct {
 
 	// Can do additional verification in a call back.
 	AddVerifyCallback AdditionalVerifyCallback
+
+	// CurrentTime overrides the clock used for certificate validity checks.
+	// It is intended for deterministic tests; production callers should leave
+	// it zero to use the current time.
+	CurrentTime time.Time
 }
 
 // IdentityConfig associates a certificate chain with a Name.

--- a/transport/handshake.go
+++ b/transport/handshake.go
@@ -512,6 +512,7 @@ func (hs *HandshakeState) certificateParserAndVerifier(rawLeaf []byte, rawInterm
 	opts := certs.VerifyOptions{}
 	if hs.certVerify != nil {
 		opts.Name = hs.certVerify.Name
+		opts.CurrentTime = hs.certVerify.CurrentTime
 	}
 	leaf := certs.Certificate{}
 	intermediate := certs.Certificate{}

--- a/transport/server_test.go
+++ b/transport/server_test.go
@@ -56,7 +56,8 @@ func newTestServerConfig(t assert.TestingT) (*ServerConfig, *VerifyConfig) {
 		HandshakeTimeout: 5 * time.Second,
 	}
 	verify := VerifyConfig{
-		Store: certs.Store{},
+		Store:       certs.Store{},
+		CurrentTime: certificate.IssuedAt.Add(time.Second),
 	}
 	verify.Store.AddCertificate(root)
 	return &server, &verify


### PR DESCRIPTION
## Summary

- add `IssueLeafAt` so callers can choose both the issuance time and validity of short-lived leaf certificates
- retain `IssueLeafWithValidity` as a convenience API that issues at `time.Now()`
- honor issuance durations and prevent children from outliving or being issued outside their parent's validity window
- enforce leaf, intermediate, and root validity windows during certificate verification
- thread a deterministic verification time through the transport verifier for tests

## Why

Hop certificates serialized issuance and expiration timestamps, but chain verification did not enforce them. `IssueLeaf` also passed a duration internally that was ignored. Together, those behaviors meant a nominally short-lived credential could continue authenticating after expiration.

Explicit issuance times also let credential vending account for the certificate wire format's whole-second timestamps without duplicating Hop's certificate signing implementation.

## Impact

Expired or not-yet-valid certificates are now rejected throughout a verified chain. Existing callers retain the one-week `IssueLeaf` default, callers that only need a custom lifetime can use `IssueLeafWithValidity`, and credential vending can specify a precise issuance time with `IssueLeafAt`.

## Validation

- `make build`
- `make test` (full race-enabled suite, including the concurrency-fixed transport and `hoptests`)
- `go test -race ./certs ./transport -count=1 -timeout 4m`
- cross-repository `hop-vend` race suite using this local `hop-go` branch

`make lint` still reports seven pre-existing `prealloc` findings in cyclist and port-forwarding files; this PR does not touch those areas.