### PR TITLE
Delete WORKSPACE file

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,1 +1,0 @@
-# Stealing the Bazel convention of marking the root of the repo with WORKSPACE


### PR DESCRIPTION
This is leftover from a previous build and test harness that was never finished and has since been deleted.

No functional impact is expected; this removes only the unused repository marker.