### PR TITLE
tubes: make outbound admission cancellable

### DIFF
--- a/common/deadline_test.go
+++ b/common/deadline_test.go
@@ -181,7 +181,7 @@ func TestDeadlineRecv(t *testing.T) {
 	wg := sync.WaitGroup{}
 	wg.Add(numLoops)
 	for i := 0; i < numLoops; i++ {
-		ch.C <- []byte{77}
+		assert.NilError(t, ch.Send([]byte{77}))
 		go func() {
 			defer wg.Done()
 			val, err := ch.Recv()
@@ -251,4 +251,81 @@ func TestDeadlineSendCancel(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+// TestDeadlineChanCloseUnblocksFullSender is the lock-ordering regression test
+// for queues whose producer is blocked on capacity. Close must publish
+// cancellation before it waits for an already registered sender.
+func TestDeadlineChanCloseUnblocksFullSender(t *testing.T) {
+	ch := NewDeadlineChan[int](1)
+	assert.NilError(t, ch.Send(1))
+
+	sendStarted := make(chan struct{})
+	sendResult := make(chan error, 1)
+	go func() {
+		close(sendStarted)
+		sendResult <- ch.Send(2)
+	}()
+	<-sendStarted
+
+	// With no receiver and a full buffer, the second send cannot complete
+	// unless Close publishes cancellation.
+	select {
+	case err := <-sendResult:
+		t.Fatalf("send returned before cancellation: %v", err)
+	default:
+	}
+
+	closeResult := make(chan error, 1)
+	go func() {
+		closeResult <- ch.Close()
+	}()
+
+	select {
+	case err := <-sendResult:
+		assert.Assert(t, errors.Is(err, io.EOF))
+	case <-time.After(time.Second):
+		t.Fatal("Close did not cancel a sender blocked on queue capacity")
+	}
+	select {
+	case err := <-closeResult:
+		assert.NilError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Close waited forever for the canceled sender")
+	}
+
+	got, err := ch.Recv()
+	assert.NilError(t, err)
+	assert.Equal(t, got, 1)
+	_, err = ch.Recv()
+	assert.Assert(t, errors.Is(err, io.EOF))
+}
+
+func TestDeadlineChanConcurrentClose(t *testing.T) {
+	ch := NewDeadlineChan[int](0)
+	const closers = 32
+	start := make(chan struct{})
+	results := make(chan error, closers)
+	for range closers {
+		go func() {
+			<-start
+			results <- ch.Close()
+		}()
+	}
+	close(start)
+
+	nilResults := 0
+	for range closers {
+		select {
+		case err := <-results:
+			if err == nil {
+				nilResults++
+			} else {
+				assert.Assert(t, errors.Is(err, io.EOF))
+			}
+		case <-time.After(time.Second):
+			t.Fatal("concurrent Close call did not observe completion")
+		}
+	}
+	assert.Equal(t, nilResults, 1)
 }

--- a/common/sync.go
+++ b/common/sync.go
@@ -120,32 +120,117 @@ func NewDeadline(t time.Time) *Deadline {
 	return d
 }
 
-// DeadlineChan is a channel of byte slices attached to a deadline.
-// It allows a caller to read and write from the channel,
-// But pending reads and writes can time out or be canceled
+// DeadlineChan is a bounded channel with deadline and close cancellation.
+//
+// Close first rejects new senders and publishes cancellation, then waits for
+// senders that registered before Close. In particular, Close never waits on a
+// mutex held by a Send blocked on capacity. Values successfully sent before
+// Close remain readable before Recv returns io.EOF. The raw channel is private
+// so callers cannot race Close with an untracked send or close it themselves.
 type DeadlineChan[T any] struct {
 	deadline *Deadline
-	closed   atomic.Bool
-	m        sync.Mutex
-	C        chan T // +checklocksignore:m
+	closing  atomic.Bool
+
+	// admissionMu protects the transition that rejects new senders. Send only
+	// holds it while registering, never while waiting for channel capacity.
+	admissionMu sync.Mutex
+	senders     sync.WaitGroup
+	closingDone chan struct{}
+	sendersDone chan struct{}
+	c           chan T
 }
 
-// Recv reads one byte slice from the underlying channel
+// Recv reads one value from the underlying channel.
 // If the deadline is exceeded, Cancel is called, or Close is called,
 // err will be set to a relevant error. Always check that err is nil before using b
 func (d *DeadlineChan[T]) Recv() (b T, err error) {
+	return d.recv()
+}
+
+func (d *DeadlineChan[T]) recv() (T, error) {
+	var zero T
 	// Return buffered data even if the channel is canceled
 	select {
-	case b = <-d.C:
-		return
+	case value := <-d.c:
+		return value, nil
 	default:
 		break
 	}
 
-	if d.closed.Load() {
-		err = io.EOF
-		return
+	if d.closing.Load() {
+		// Close publishes cancellation before waiting for registered senders.
+		// Wait for those senders to resolve, then recheck the buffer so a send
+		// that linearized before Close is still observable.
+		<-d.sendersDone
+		select {
+		case value := <-d.c:
+			return value, nil
+		default:
+			return zero, io.EOF
+		}
 	}
+
+	errChan := d.deadline.Done()
+	select {
+	case <-errChan:
+		if d.closing.Load() {
+			return d.RecvQueued()
+		}
+		return zero, d.deadline.Err()
+	default:
+		select {
+		case <-errChan:
+			if d.closing.Load() {
+				return d.RecvQueued()
+			}
+			return zero, d.deadline.Err()
+		case value := <-d.c:
+			return value, nil
+		}
+	}
+}
+
+// RecvQueued receives values without observing operation deadlines. It is for
+// an owning queue consumer that must keep draining values accepted before
+// Close. Close still wakes it, after every registered sender has resolved.
+func (d *DeadlineChan[T]) RecvQueued() (b T, err error) {
+	for {
+		select {
+		case b = <-d.c:
+			return b, nil
+		default:
+		}
+
+		if d.closing.Load() {
+			<-d.sendersDone
+			select {
+			case b = <-d.c:
+				return b, nil
+			default:
+				return b, io.EOF
+			}
+		}
+
+		select {
+		case b = <-d.c:
+			return b, nil
+		case <-d.closingDone:
+		}
+	}
+}
+
+// Send writes one value to the underlying channel.
+// If the deadline is exceeded, Cancel is called, or Close is called,
+// err will not be nil.
+func (d *DeadlineChan[T]) Send(b T) (err error) {
+	d.admissionMu.Lock()
+	if d.closing.Load() {
+		d.admissionMu.Unlock()
+		return io.EOF
+	}
+	d.senders.Add(1)
+	d.admissionMu.Unlock()
+	defer d.senders.Done()
 
 	errChan := d.deadline.Done()
 	select {
@@ -157,42 +242,52 @@ func (d *DeadlineChan[T]) Recv() (b T, err error) {
 		case <-errChan:
 			err = d.deadline.Err()
 			return
-		case b = <-d.C:
+		case d.c <- b:
 			return
 		}
 	}
 }
 
-// Send send one byte slice on the underlying channel
-// If the deadline is exceeded, Cancel is called, or Close is called,
-// err will not be nil.
-func (d *DeadlineChan[T]) Send(b T) (err error) {
-	d.m.Lock()
-	defer d.m.Unlock()
-
-	if d.closed.Load() {
-		return io.EOF
+// TrySend attempts to send b without blocking. It returns false if the channel
+// has no capacity, has been canceled, or is closing.
+func (d *DeadlineChan[T]) TrySend(b T) bool {
+	d.admissionMu.Lock()
+	if d.closing.Load() {
+		d.admissionMu.Unlock()
+		return false
 	}
+	d.senders.Add(1)
+	d.admissionMu.Unlock()
+	defer d.senders.Done()
 
 	errChan := d.deadline.Done()
 	select {
 	case <-errChan:
-		err = d.deadline.Err()
-		return
+		return false
 	default:
-		select {
-		case <-errChan:
-			err = d.deadline.Err()
-			return
-		case d.C <- b:
-			return
-		}
 	}
+
+	select {
+	case <-errChan:
+		return false
+	case d.c <- b:
+		return true
+	default:
+		return false
+	}
+}
+
+// Len returns the number of buffered values. It is intended for diagnostics
+// and tests; callers must not use it to coordinate concurrent operations.
+func (d *DeadlineChan[T]) Len() int {
+	return len(d.c)
 }
 
 // SetDeadline sets a time at which calls to Send and Recv will timeout
 func (d *DeadlineChan[T]) SetDeadline(t time.Time) error {
-	if d.closed.Load() {
+	d.admissionMu.Lock()
+	defer d.admissionMu.Unlock()
+	if d.closing.Load() {
 		return io.EOF
 	}
 	return d.deadline.SetDeadline(t)
@@ -201,7 +296,9 @@ func (d *DeadlineChan[T]) SetDeadline(t time.Time) error {
 // Cancel cancels pending calls to Send and Recv and causes them to return err
 // TODO(hosono) when should Recv return buffered data
 func (d *DeadlineChan[T]) Cancel(err error) error {
-	if d.closed.Load() {
+	d.admissionMu.Lock()
+	defer d.admissionMu.Unlock()
+	if d.closing.Load() {
 		return io.EOF
 	}
 	d.deadline.Cancel(err)
@@ -211,22 +308,29 @@ func (d *DeadlineChan[T]) Cancel(err error) error {
 // Close cancels pending calls to Send and Recv. Those calls will return
 // io.EOF rather than os.ErrDeadlineExceeded even after the deadline has expired
 func (d *DeadlineChan[T]) Close() error {
-	d.m.Lock()
-	defer d.m.Unlock()
-
-	if d.closed.Load() {
+	d.admissionMu.Lock()
+	if d.closing.Load() {
+		d.admissionMu.Unlock()
+		<-d.sendersDone
 		return io.EOF
 	}
-	d.closed.Store(true)
+	d.closing.Store(true)
+	close(d.closingDone)
+	// Cancellation is published while no blocked Send holds admissionMu.
 	d.deadline.Cancel(io.EOF)
+	d.admissionMu.Unlock()
+
+	d.senders.Wait()
+	close(d.sendersDone)
 	return nil
 }
 
 // NewDeadlineChan returns a pointer to a DeadlineChan with capacity of size
 func NewDeadlineChan[T any](size int) *DeadlineChan[T] {
 	return &DeadlineChan[T]{
-		deadline: NewDeadline(time.Time{}),
-		m:        sync.Mutex{},
-		C:        make(chan T, size),
+		deadline:    NewDeadline(time.Time{}),
+		closingDone: make(chan struct{}),
+		sendersDone: make(chan struct{}),
+		c:           make(chan T, size),
 	}
 }

--- a/internal/checkblockinglocks/main.go
+++ b/internal/checkblockinglocks/main.go
@@ -1,0 +1,298 @@
+// Command checkblockinglocks rejects blocking queue, channel, wait, and socket
+// operations performed while a state or lifecycle mutex is held.
+//
+// It intentionally complements checklocks: checklocks verifies protected data,
+// while this command verifies the package's shutdown/liveness lock discipline.
+package main
+
+import (
+	"bytes"
+	"fmt"
+	"go/ast"
+	"go/format"
+	"go/parser"
+	"go/token"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+type lockSet map[string]int
+
+func (s lockSet) clone() lockSet {
+	copy := make(lockSet, len(s))
+	for name, count := range s {
+		copy[name] = count
+	}
+	return copy
+}
+
+func mergeLocks(sets ...lockSet) lockSet {
+	merged := make(lockSet)
+	for _, set := range sets {
+		for name, count := range set {
+			if count > merged[name] {
+				merged[name] = count
+			}
+		}
+	}
+	return merged
+}
+
+type analyzer struct {
+	fset        *token.FileSet
+	diagnostics []string
+}
+
+func (a *analyzer) report(node ast.Node, held lockSet, operation string) {
+	locks := make([]string, 0, len(held))
+	for name, count := range held {
+		if count > 0 {
+			locks = append(locks, name)
+		}
+	}
+	if len(locks) == 0 {
+		return
+	}
+	a.diagnostics = append(a.diagnostics, fmt.Sprintf(
+		"%s: blocking %s while lifecycle/state lock(s) %s are held",
+		a.fset.Position(node.Pos()), operation, strings.Join(locks, ", "),
+	))
+}
+
+func exprString(fset *token.FileSet, expr ast.Expr) string {
+	var out bytes.Buffer
+	if err := format.Node(&out, fset, expr); err != nil {
+		return "<unknown>"
+	}
+	return out.String()
+}
+
+func lockName(fset *token.FileSet, call *ast.CallExpr) (name, action string, ok bool) {
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || (selector.Sel.Name != "Lock" && selector.Sel.Name != "Unlock") {
+		return "", "", false
+	}
+
+	var field string
+	switch receiver := selector.X.(type) {
+	case *ast.Ident:
+		field = receiver.Name
+	case *ast.SelectorExpr:
+		field = receiver.Sel.Name
+	}
+	if field != "l" && field != "m" && field != "lifecycleMu" {
+		return "", "", false
+	}
+	return exprString(fset, selector.X), selector.Sel.Name, true
+}
+
+func directLockOperation(fset *token.FileSet, statement ast.Stmt) (name, action string, ok bool) {
+	expression, ok := statement.(*ast.ExprStmt)
+	if !ok {
+		return "", "", false
+	}
+	call, ok := expression.X.(*ast.CallExpr)
+	if !ok {
+		return "", "", false
+	}
+	return lockName(fset, call)
+}
+
+func (a *analyzer) checkBlockingExpressions(node ast.Node, held lockSet) {
+	ast.Inspect(node, func(node ast.Node) bool {
+		switch value := node.(type) {
+		case *ast.FuncLit:
+			// A closure has its own execution context. Analyze its lock state from
+			// scratch rather than inheriting locks held while it is created.
+			a.checkBlock(value.Body.List, make(lockSet))
+			return false
+		case *ast.UnaryExpr:
+			if value.Op == token.ARROW {
+				a.report(value, held, "channel receive")
+			}
+		case *ast.CallExpr:
+			selector, ok := value.Fun.(*ast.SelectorExpr)
+			if !ok {
+				return true
+			}
+			receiver := exprString(a.fset, selector.X)
+			switch selector.Sel.Name {
+			case "Send", "Recv", "RecvQueued", "Wait", "WaitForClose", "enqueue":
+				a.report(value, held, selector.Sel.Name+" call")
+			case "Read", "ReadMsg", "ReadMsgUDP", "Write", "WriteMsg", "WriteMsgUDP", "Close":
+				if strings.Contains(receiver, "underlying") || strings.Contains(receiver, "udpConn") {
+					a.report(value, held, selector.Sel.Name+" on "+receiver)
+				}
+			}
+		}
+		return true
+	})
+}
+
+func selectHasDefault(statement *ast.SelectStmt) bool {
+	for _, item := range statement.Body.List {
+		clause := item.(*ast.CommClause)
+		if clause.Comm == nil {
+			return true
+		}
+	}
+	return false
+}
+
+func (a *analyzer) checkBlock(statements []ast.Stmt, held lockSet) lockSet {
+	current := held.clone()
+	for _, statement := range statements {
+		if name, action, ok := directLockOperation(a.fset, statement); ok {
+			switch action {
+			case "Lock":
+				current[name]++
+			case "Unlock":
+				if current[name] > 0 {
+					current[name]--
+				}
+			}
+			continue
+		}
+
+		switch value := statement.(type) {
+		case *ast.BlockStmt:
+			current = a.checkBlock(value.List, current)
+		case *ast.IfStmt:
+			base := current.clone()
+			if value.Init != nil {
+				base = a.checkBlock([]ast.Stmt{value.Init}, base)
+			}
+			a.checkBlockingExpressions(value.Cond, base)
+			branches := []lockSet{a.checkBlock(value.Body.List, base)}
+			if value.Else == nil {
+				branches = append(branches, base)
+			} else {
+				branches = append(branches, a.checkBlock([]ast.Stmt{value.Else}, base))
+			}
+			current = mergeLocks(branches...)
+		case *ast.ForStmt:
+			loop := current.clone()
+			if value.Init != nil {
+				loop = a.checkBlock([]ast.Stmt{value.Init}, loop)
+			}
+			if value.Cond != nil {
+				a.checkBlockingExpressions(value.Cond, loop)
+			}
+			a.checkBlock(value.Body.List, loop)
+			if value.Post != nil {
+				a.checkBlock([]ast.Stmt{value.Post}, loop)
+			}
+		case *ast.RangeStmt:
+			a.checkBlockingExpressions(value.X, current)
+			a.checkBlock(value.Body.List, current)
+		case *ast.SelectStmt:
+			if !selectHasDefault(value) {
+				a.report(value, current, "select")
+			}
+			branches := make([]lockSet, 0, len(value.Body.List))
+			for _, item := range value.Body.List {
+				clause := item.(*ast.CommClause)
+				branches = append(branches, a.checkBlock(clause.Body, current))
+			}
+			if len(branches) > 0 {
+				current = mergeLocks(branches...)
+			}
+		case *ast.SwitchStmt:
+			base := current.clone()
+			if value.Init != nil {
+				base = a.checkBlock([]ast.Stmt{value.Init}, base)
+			}
+			if value.Tag != nil {
+				a.checkBlockingExpressions(value.Tag, base)
+			}
+			branches := make([]lockSet, 1, 1+len(value.Body.List))
+			branches[0] = base
+			for _, item := range value.Body.List {
+				clause := item.(*ast.CaseClause)
+				branches = append(branches, a.checkBlock(clause.Body, base))
+			}
+			current = mergeLocks(branches...)
+		case *ast.TypeSwitchStmt:
+			base := current.clone()
+			if value.Init != nil {
+				base = a.checkBlock([]ast.Stmt{value.Init}, base)
+			}
+			branches := make([]lockSet, 1, 1+len(value.Body.List))
+			branches[0] = base
+			for _, item := range value.Body.List {
+				clause := item.(*ast.CaseClause)
+				branches = append(branches, a.checkBlock(clause.Body, base))
+			}
+			current = mergeLocks(branches...)
+		case *ast.LabeledStmt:
+			current = a.checkBlock([]ast.Stmt{value.Stmt}, current)
+		case *ast.SendStmt:
+			a.report(value, current, "channel send")
+			a.checkBlockingExpressions(value.Value, current)
+		default:
+			a.checkBlockingExpressions(statement, current)
+		}
+	}
+	return current
+}
+
+func analyzeFile(path string) ([]string, error) {
+	fset := token.NewFileSet()
+	parsed, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	analyzer := &analyzer{fset: fset}
+	for _, declaration := range parsed.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if ok && function.Body != nil {
+			analyzer.checkBlock(function.Body.List, make(lockSet))
+		}
+	}
+	return analyzer.diagnostics, nil
+}
+
+func run(paths []string) error {
+	var diagnostics []string
+	for _, root := range paths {
+		// CLI arguments intentionally select the directories to audit.
+		//nolint:gosec
+		err := filepath.WalkDir(root, func(path string, entry fs.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if entry.IsDir() || !strings.HasSuffix(path, ".go") || strings.HasSuffix(path, "_test.go") {
+				return nil
+			}
+			found, err := analyzeFile(path)
+			if err != nil {
+				return err
+			}
+			diagnostics = append(diagnostics, found...)
+			return nil
+		})
+		if err != nil {
+			return err
+		}
+	}
+	for _, diagnostic := range diagnostics {
+		fmt.Fprintln(os.Stderr, diagnostic)
+	}
+	if len(diagnostics) != 0 {
+		return fmt.Errorf("found %d blocking operation(s) under lifecycle/state locks", len(diagnostics))
+	}
+	return nil
+}
+
+func main() {
+	paths := os.Args[1:]
+	if len(paths) == 0 {
+		paths = []string{"./tubes", "./transport"}
+	}
+	if err := run(paths); err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(1)
+	}
+}

--- a/internal/checkblockinglocks/main_test.go
+++ b/internal/checkblockinglocks/main_test.go
@@ -1,0 +1,53 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func analyzeTestSource(t *testing.T, source string) []string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "input.go")
+	if err := os.WriteFile(path, []byte(source), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	diagnostics, err := analyzeFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return diagnostics
+}
+
+func TestRejectsBlockingChannelOperationUnderLock(t *testing.T) {
+	diagnostics := analyzeTestSource(t, `package p
+import "sync"
+type owner struct { l sync.Mutex; queue chan int }
+func send(o *owner) {
+	o.l.Lock()
+	defer o.l.Unlock()
+	o.queue <- 1
+}`)
+	if len(diagnostics) != 1 {
+		t.Fatalf("got %d diagnostics, want 1: %v", len(diagnostics), diagnostics)
+	}
+}
+
+func TestAcceptsCancellationAndAdmissionAfterUnlock(t *testing.T) {
+	diagnostics := analyzeTestSource(t, `package p
+import "sync"
+type owner struct { lifecycleMu sync.Mutex; queue chan int }
+func send(o *owner) {
+	o.lifecycleMu.Lock()
+	o.lifecycleMu.Unlock()
+	o.queue <- 1
+}
+func trySend(o *owner) {
+	o.lifecycleMu.Lock()
+	defer o.lifecycleMu.Unlock()
+	select { case o.queue <- 1: default: }
+}`)
+	if len(diagnostics) != 0 {
+		t.Fatalf("unexpected diagnostics: %v", diagnostics)
+	}
+}

--- a/makefile
+++ b/makefile
@@ -18,6 +18,7 @@ CONCURRENCY_TEST_PROCS := 1 2 4
 .PHONY: vet
 vet: ## run go vet. Currently, this only checks for deadlocks
 vet:
+	go run ./internal/checkblockinglocks ./tubes ./transport
 	go vet -vettool=$$HOME/go/bin/checklocks ./...
 
 .PHONY: lint

--- a/transport/client.go
+++ b/transport/client.go
@@ -490,10 +490,7 @@ func (c *Client) handleSessionMessage(addr *net.UDPAddr, msg []byte) error {
 
 	switch mt {
 	case MessageTypeTransport:
-		select {
-		case c.ss.handle.recv.C <- plaintext:
-			break
-		default:
+		if !c.ss.handle.recv.TrySend(plaintext) {
 			logrus.Warnf("session %x: recv queue full, dropping packet", sessionID)
 		}
 	case MessageTypeControl:

--- a/transport/concurrency_test.go
+++ b/transport/concurrency_test.go
@@ -335,8 +335,8 @@ func TestCloseUnblocksInFlightOperations(t *testing.T) {
 // Expected: Buffered messages are delivered; after exhaustion, reads return EOF.
 func TestBufferedDataReturnedAfterClose(t *testing.T) {
 	h := newConcurrencyTestHandle(newConcurrencyTestConn(), 2)
-	h.recv.C <- []byte("one")
-	h.recv.C <- []byte("two")
+	assert.Assert(t, h.recv.TrySend([]byte("one")))
+	assert.Assert(t, h.recv.TrySend([]byte("two")))
 	assert.NilError(t, h.Close())
 
 	buf := make([]byte, 3)

--- a/transport/doc.go
+++ b/transport/doc.go
@@ -15,6 +15,12 @@
 // A SessionState mutex protects session lifecycle, counters, and cryptographic
 // state. Handle's read and write locks serialize their respective operations.
 // Packet state is updated while locked, but socket I/O happens after releasing
-// the session mutex. SessionState.closeLocked is the sole session-close
-// transition and closes the receive queue to unblock all readers.
+// the session mutex. Receive loops use DeadlineChan.TrySend while holding the
+// session mutex, so a full application queue drops a packet instead of blocking
+// lifecycle progress. SessionState.closeLocked is the sole session-close
+// transition and owns closing the receive queue to unblock all readers.
+//
+// State and lifecycle mutexes never span channel waits, wait-group waits, queue
+// admission, or socket I/O. The checkblockinglocks command run by make vet
+// enforces these known blocking-operation boundaries.
 package transport

--- a/transport/server.go
+++ b/transport/server.go
@@ -487,10 +487,7 @@ func (s *Server) handleSessionMessage(addr *net.UDPAddr, msg []byte) error {
 
 	switch mt {
 	case MessageTypeTransport:
-		select {
-		case ss.handle.recv.C <- plaintext:
-			break
-		default:
+		if !ss.handle.recv.TrySend(plaintext) {
 			logrus.Warnf("session %x: recv queue full, dropping packet", sessionID)
 		}
 	case MessageTypeControl:
@@ -745,20 +742,17 @@ func (s *Server) Close() (err error) {
 	s.lifecycleMu.Lock()
 	for {
 		cur := serverState(s.state.Load())
-		switch cur {
-		case serverStateClosing, serverStateClosed:
+		if cur == serverStateClosing || cur == serverStateClosed {
 			s.lifecycleMu.Unlock()
 			<-s.closeDone
 			return s.closeErr
-		default:
-			if s.state.CompareAndSwap(uint32(cur), uint32(serverStateClosing)) {
-				s.lifecycleMu.Unlock()
-				goto closing
-			}
+		}
+		if s.state.CompareAndSwap(uint32(cur), uint32(serverStateClosing)) {
+			break
 		}
 	}
+	s.lifecycleMu.Unlock()
 
-closing:
 	// Closing the socket unblocks both the Serve read loop and any in-flight
 	// writes before we wait for workers or acquire per-session locks.
 	s.closeErr = s.udpConn.Close()

--- a/tubes/concurrency_test.go
+++ b/tubes/concurrency_test.go
@@ -13,17 +13,45 @@ import (
 	"hop.computer/hop/common"
 )
 
+func newRecordingOutbox(t *testing.T) (*outbox, <-chan outboundFrame) {
+	t.Helper()
+	o := newOutbox()
+	recorded := make(chan outboundFrame, 1024)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case raw := <-o.priority:
+				recorded <- outboundFrame{bytes: raw, priority: true}
+			case raw := <-o.normal:
+				recorded <- outboundFrame{bytes: raw}
+			case <-o.aborted:
+				return
+			case <-o.stop:
+				return
+			}
+		}
+	}()
+	t.Cleanup(func() {
+		o.requestStop()
+		<-done
+	})
+	return o, recorded
+}
+
 // TestReliablePublishesClosedBeforeSenderDrain verifies that late packet
 // handlers reject new work while shutdown waits for the sender consumer.
 func TestReliablePublishesClosedBeforeSenderDrain(t *testing.T) {
 	log := logrus.WithField("test", t.Name())
 	r := &Reliable{
-		sender:     newSender(log),
-		recvWindow: newReceiver(log),
-		tubeState:  initiated,
-		closed:     make(chan struct{}),
-		sendDone:   make(chan struct{}),
-		log:        log,
+		sender:         newSender(log),
+		recvWindow:     newReceiver(log),
+		tubeState:      initiated,
+		closed:         make(chan struct{}),
+		closeRequested: make(chan struct{}),
+		sendDone:       make(chan struct{}),
+		log:            log,
 	}
 	r.l.Lock()
 	r.sender.closed.Store(false)
@@ -83,14 +111,15 @@ func TestReliableOwnsSenderQueueClosure(t *testing.T) {
 func TestReliableForcedCloseStopsResponderInit(t *testing.T) {
 	log := logrus.WithField("test", t.Name())
 	r := &Reliable{
-		sender:     newSender(log),
-		recvWindow: newReceiver(log),
-		tubeState:  created,
-		closed:     make(chan struct{}),
-		initRecv:   make(chan struct{}),
-		initDone:   make(chan struct{}),
-		sendDone:   make(chan struct{}),
-		log:        log,
+		sender:         newSender(log),
+		recvWindow:     newReceiver(log),
+		tubeState:      created,
+		closed:         make(chan struct{}),
+		closeRequested: make(chan struct{}),
+		initRecv:       make(chan struct{}),
+		initDone:       make(chan struct{}),
+		sendDone:       make(chan struct{}),
+		log:            log,
 	}
 	r.l.Lock()
 	r.sender.closed.Store(true)
@@ -113,16 +142,18 @@ func TestReliableForcedCloseStopsResponderInit(t *testing.T) {
 // winning concurrently with a retransmit check is success, not cancellation.
 func TestReliableInitiationGuardStartsSenderAfterResponse(t *testing.T) {
 	log := logrus.WithField("test", t.Name())
+	outbound, recorded := newRecordingOutbox(t)
 	r := &Reliable{
-		sender:     newSender(log),
-		recvWindow: newReceiver(log),
-		sendQueue:  make(chan []byte, 1),
-		tubeState:  created,
-		closed:     make(chan struct{}),
-		initRecv:   make(chan struct{}),
-		initDone:   make(chan struct{}),
-		sendDone:   make(chan struct{}),
-		log:        log,
+		sender:         newSender(log),
+		recvWindow:     newReceiver(log),
+		outbound:       outbound,
+		tubeState:      created,
+		closed:         make(chan struct{}),
+		closeRequested: make(chan struct{}),
+		initRecv:       make(chan struct{}),
+		initDone:       make(chan struct{}),
+		sendDone:       make(chan struct{}),
+		log:            log,
 	}
 	r.l.Lock()
 	r.sender.closed.Store(true)
@@ -140,9 +171,10 @@ func TestReliableInitiationGuardStartsSenderAfterResponse(t *testing.T) {
 		t.Fatal("successful initiation did not enable the reliable sender")
 	}
 
-	r.sender.sendQueue <- &frame{data: []byte("started"), dataLength: 7}
+	_, err := r.Write([]byte("started"))
+	assert.NilError(t, err)
 	select {
-	case <-r.sendQueue:
+	case <-recorded:
 	case <-time.After(time.Second):
 		t.Fatal("reliable sender did not hand queued frame to the muxer")
 	}
@@ -158,13 +190,14 @@ func TestReliableInitiationGuardStartsSenderAfterResponse(t *testing.T) {
 func TestReliableForcedCloseBeforeSenderStart(t *testing.T) {
 	log := logrus.WithField("test", t.Name())
 	r := &Reliable{
-		sender:     newSender(log),
-		recvWindow: newReceiver(log),
-		tubeState:  initiated,
-		closed:     make(chan struct{}),
-		initDone:   make(chan struct{}),
-		sendDone:   make(chan struct{}),
-		log:        log,
+		sender:         newSender(log),
+		recvWindow:     newReceiver(log),
+		tubeState:      initiated,
+		closed:         make(chan struct{}),
+		closeRequested: make(chan struct{}),
+		initDone:       make(chan struct{}),
+		sendDone:       make(chan struct{}),
+		log:            log,
 	}
 	r.l.Lock()
 	r.sender.closed.Store(true)
@@ -178,12 +211,13 @@ func TestReliableForcedCloseBeforeSenderStart(t *testing.T) {
 // TestUnreliableCloseQueuesFINLast verifies that Close stops writers before
 // placing the FIN behind every message already accepted into the local queue.
 func TestUnreliableCloseQueuesFINLast(t *testing.T) {
+	outbound, recorded := newRecordingOutbox(t)
 	initiatedCh := make(chan struct{})
 	close(initiatedCh)
 	initiateDone := make(chan struct{})
 	close(initiateDone)
 	u := &Unreliable{
-		sendQueue:    make(chan []byte, 2),
+		outbound:     outbound,
 		initiated:    initiatedCh,
 		initiateDone: initiateDone,
 		stopInitiate: make(chan struct{}),
@@ -200,11 +234,11 @@ func TestUnreliableCloseQueuesFINLast(t *testing.T) {
 	assert.NilError(t, u.Close())
 	assert.Assert(t, errors.Is(u.WriteMsg([]byte("after close")), io.EOF))
 
-	dataFrame, err := fromBytes(<-u.sendQueue)
+	dataFrame, err := fromBytes((<-recorded).bytes)
 	assert.NilError(t, err)
 	assert.Assert(t, !dataFrame.flags.FIN)
 
-	finFrame, err := fromBytes(<-u.sendQueue)
+	finFrame, err := fromBytes((<-recorded).bytes)
 	assert.NilError(t, err)
 	assert.Assert(t, finFrame.flags.FIN)
 }
@@ -212,8 +246,9 @@ func TestUnreliableCloseQueuesFINLast(t *testing.T) {
 // TestUnreliableInitiationGuardStartsSenderAfterResponse verifies that a
 // response observed at the retransmit guard still starts the sender consumer.
 func TestUnreliableInitiationGuardStartsSenderAfterResponse(t *testing.T) {
+	outbound, recorded := newRecordingOutbox(t)
 	u := &Unreliable{
-		sendQueue:    make(chan []byte, 2),
+		outbound:     outbound,
 		initiated:    make(chan struct{}),
 		initiateDone: make(chan struct{}),
 		stopInitiate: make(chan struct{}),
@@ -238,8 +273,8 @@ func TestUnreliableInitiationGuardStartsSenderAfterResponse(t *testing.T) {
 
 	assert.NilError(t, u.send.Send([]byte("started")))
 	select {
-	case got := <-u.sendQueue:
-		assert.DeepEqual(t, got, []byte("started"))
+	case got := <-recorded:
+		assert.DeepEqual(t, got.bytes, []byte("started"))
 	case <-time.After(time.Second):
 		t.Fatal("unreliable sender did not hand queued message to the muxer")
 	}
@@ -257,5 +292,222 @@ func TestUnreliableRejectsReceiveAfterClose(t *testing.T) {
 
 	err := u.receive(&frame{data: []byte("late"), dataLength: 4})
 	assert.Assert(t, errors.Is(err, ErrBadTubeState))
-	assert.Equal(t, len(u.recv.C), 0)
+	assert.Equal(t, u.recv.Len(), 0)
+}
+
+// TestUnreliableResponderWaitsForInitiationRequest forces the responder
+// initiation goroutine to run before the Muxer dispatches the peer's request.
+// The sender must wait for that event instead of exiting permanently.
+func TestUnreliableResponderWaitsForInitiationRequest(t *testing.T) {
+	outbound, recorded := newRecordingOutbox(t)
+	u := &Unreliable{
+		outbound:     outbound,
+		initiated:    make(chan struct{}),
+		initiateDone: make(chan struct{}),
+		stopInitiate: make(chan struct{}),
+		senderDone:   make(chan struct{}),
+		closed:       make(chan struct{}),
+		recv:         common.NewDeadlineChan[[]byte](1),
+		send:         common.NewDeadlineChan[[]byte](1),
+		log:          logrus.WithField("test", t.Name()),
+	}
+	u.state.Store(created)
+	go u.initiate(false)
+	runtime.Gosched()
+
+	select {
+	case <-u.initiateDone:
+		t.Fatal("responder initiation exited before receiving the request")
+	default:
+	}
+
+	assert.NilError(t, u.receiveInitiatePkt(&initiateFrame{flags: frameFlags{REQ: true}}))
+	select {
+	case admitted := <-recorded:
+		response := fromInitiateBytes(admitted.bytes)
+		assert.Assert(t, response.flags.RESP)
+	case <-time.After(time.Second):
+		t.Fatal("responder did not admit its initiation response")
+	}
+	select {
+	case <-u.initiateDone:
+	case <-time.After(time.Second):
+		t.Fatal("responder initiation did not complete after the request")
+	}
+
+	assert.NilError(t, u.WriteMsg([]byte("sender started")))
+	select {
+	case admitted := <-recorded:
+		pkt, err := fromBytes(admitted.bytes)
+		assert.NilError(t, err)
+		assert.DeepEqual(t, pkt.data, []byte("sender started"))
+	case <-time.After(time.Second):
+		t.Fatal("responder sender did not run after initiation")
+	}
+	assert.NilError(t, u.Close())
+}
+
+func TestReliableCloseCancelsBlockedInitiationAdmission(t *testing.T) {
+	log := logrus.WithField("test", t.Name())
+	r := &Reliable{
+		sender:         newSender(log),
+		recvWindow:     newReceiver(log),
+		outbound:       newOutbox(),
+		tubeState:      created,
+		closed:         make(chan struct{}),
+		closeRequested: make(chan struct{}),
+		initRecv:       make(chan struct{}),
+		initDone:       make(chan struct{}),
+		sendDone:       make(chan struct{}),
+		log:            log,
+	}
+	r.sender.closed.Store(true)
+	go r.initiate(true)
+	runtime.Gosched()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- r.Close()
+	}()
+	select {
+	case err := <-result:
+		assert.Assert(t, errors.Is(err, ErrBadTubeState))
+	case <-time.After(time.Second):
+		t.Fatal("Reliable.Close did not cancel blocked initiation admission")
+	}
+	r.WaitForClose()
+}
+
+func TestUnreliableCloseCancelsBlockedInitiationAdmission(t *testing.T) {
+	u := &Unreliable{
+		outbound:     newOutbox(),
+		initiated:    make(chan struct{}),
+		initiateDone: make(chan struct{}),
+		stopInitiate: make(chan struct{}),
+		senderDone:   make(chan struct{}),
+		closed:       make(chan struct{}),
+		recv:         common.NewDeadlineChan[[]byte](1),
+		send:         common.NewDeadlineChan[[]byte](1),
+		log:          logrus.WithField("test", t.Name()),
+	}
+	u.state.Store(created)
+	go u.initiate(true)
+	runtime.Gosched()
+
+	result := make(chan error, 1)
+	go func() {
+		result <- u.Close()
+	}()
+	select {
+	case err := <-result:
+		assert.NilError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Unreliable.Close did not cancel blocked initiation admission")
+	}
+}
+
+func TestUnreliableCloseCancelsWriterUnderBackpressure(t *testing.T) {
+	outbound := newOutbox()
+	initiatedCh := make(chan struct{})
+	close(initiatedCh)
+	initiateDone := make(chan struct{})
+	close(initiateDone)
+	u := &Unreliable{
+		outbound:     outbound,
+		initiated:    initiatedCh,
+		initiateDone: initiateDone,
+		stopInitiate: make(chan struct{}),
+		senderDone:   make(chan struct{}),
+		closed:       make(chan struct{}),
+		recv:         common.NewDeadlineChan[[]byte](1),
+		send:         common.NewDeadlineChan[[]byte](1),
+		log:          logrus.WithField("test", t.Name()),
+	}
+	u.state.Store(initiated)
+	go u.sender()
+
+	assert.NilError(t, u.WriteMsg([]byte("blocked at outbox")))
+	deadline := time.Now().Add(time.Second)
+	for u.send.Len() != 0 && time.Now().Before(deadline) {
+		runtime.Gosched()
+	}
+	assert.Equal(t, u.send.Len(), 0, "sender did not reach blocked outbox admission")
+	assert.NilError(t, u.WriteMsg([]byte("fills local queue")))
+
+	writeStarted := make(chan struct{})
+	writeResult := make(chan error, 1)
+	go func() {
+		close(writeStarted)
+		writeResult <- u.WriteMsg([]byte("blocked on local queue"))
+	}()
+	<-writeStarted
+	runtime.Gosched()
+
+	closeResult := make(chan error, 1)
+	go func() {
+		closeResult <- u.Close()
+	}()
+	select {
+	case err := <-writeResult:
+		assert.Assert(t, errors.Is(err, io.EOF))
+	case <-time.After(time.Second):
+		t.Fatal("Close could not cancel a writer blocked by local backpressure")
+	}
+
+	// Close is still correctly waiting for its sender; transport failure now
+	// releases the blocked Muxer admission and completes the drain.
+	outbound.abort(errors.New("test transport failure"))
+	select {
+	case err := <-closeResult:
+		assert.NilError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Close did not complete after outbound failure")
+	}
+}
+
+func TestUnreliableConcurrentClose(t *testing.T) {
+	outbound, _ := newRecordingOutbox(t)
+	initiatedCh := make(chan struct{})
+	close(initiatedCh)
+	initiateDone := make(chan struct{})
+	close(initiateDone)
+	u := &Unreliable{
+		outbound:     outbound,
+		initiated:    initiatedCh,
+		initiateDone: initiateDone,
+		stopInitiate: make(chan struct{}),
+		senderDone:   make(chan struct{}),
+		closed:       make(chan struct{}),
+		recv:         common.NewDeadlineChan[[]byte](1),
+		send:         common.NewDeadlineChan[[]byte](1),
+		log:          logrus.WithField("test", t.Name()),
+	}
+	u.state.Store(initiated)
+	go u.sender()
+
+	const closers = 32
+	start := make(chan struct{})
+	results := make(chan error, closers)
+	for range closers {
+		go func() {
+			<-start
+			results <- u.Close()
+		}()
+	}
+	close(start)
+
+	nilResults := 0
+	for range closers {
+		select {
+		case err := <-results:
+			if err == nil {
+				nilResults++
+			} else {
+				assert.Assert(t, errors.Is(err, io.EOF))
+			}
+		case <-time.After(time.Second):
+			t.Fatal("concurrent Close did not return")
+		}
+	}
+	assert.Equal(t, nilResults, 1)
 }

--- a/tubes/doc.go
+++ b/tubes/doc.go
@@ -2,21 +2,32 @@
 //
 // # Concurrency model
 //
-// A Muxer owns one receiver and one sender goroutine. Its mutex protects the
-// tube maps and elects the first Stop caller as the shutdown owner; later calls
-// wait for the stopped channel, whose close publishes the cached results.
+// A Muxer owns one transport receiver and one transport sender goroutine. The
+// sender is the only reader of the Muxer's two raw outbound queues and the only
+// writer to the underlying transport. Tubes submit frames through the Muxer's
+// cancellable outbox; they cannot access or close either raw queue. The queues
+// are never closed. Separate stop and abort channels prevent send-on-closed
+// races and wake both normal and priority admissions on failure. A distinct
+// stopping broadcast wakes Accept and remote-tube queue admission immediately;
+// stopped remains the completion publication for concurrent Stop callers.
 //
-// Each Reliable's lifecycle mutex serializes state-machine transitions. Its
-// sender has a separate mutex for acknowledgements and retransmission state;
-// when both are needed, the Reliable mutex is acquired first. Closing releases
-// the lifecycle mutex while waiting for the tube sender to drain, and actual
-// socket I/O belongs solely to the Muxer sender.
+// Lifecycle and state mutexes protect only bounded in-memory transitions. Code
+// must not hold one while waiting on a channel, wait group, queue admission, or
+// socket operation. Cancellation is therefore always publishable by Close or
+// Stop, including with GOMAXPROCS=1. The checkblockinglocks command, run by
+// make vet, mechanically enforces known blocking operations in tubes and
+// transport.
 //
-// Shutdown proceeds from producers to consumers. Tubes reject new work, close
-// and drain their sender queues, and then the Muxer closes its queues. One
-// shutdown deadline bounds that entire chain: on expiry, closing the underlying
-// connection unblocks the Muxer sender, which drains queued handoffs so upstream
-// producers can exit. This ordering normally writes the final reliable FIN
-// acknowledgement, never sends on a closed queue, and cannot wait forever on a
-// stuck transport write.
+// Reliable state transitions reserve frames while locked and admit them only
+// after unlocking. Its local wake channels are owned and closed by Reliable;
+// the final FIN acknowledgement is reserved before terminal sender cancellation
+// and admitted before close completion. Unreliable uses DeadlineChan as its
+// bounded local queue: Close rejects writers and cancels blocked Send calls,
+// then the sole sender drains accepted data and admits FIN last.
+//
+// Shutdown proceeds from producers to consumers. Tubes reject new work and join
+// their producers before Muxer requests sender stop. A transport write failure
+// aborts the outbox before starting Stop, immediately waking both admission
+// priorities. A bounded fallback closes the underlying transport to interrupt a
+// stuck write; completion channels publish cached results to concurrent callers.
 package tubes

--- a/tubes/muxer.go
+++ b/tubes/muxer.go
@@ -54,19 +54,20 @@ type Muxer struct {
 	// +checklocks:m
 	unreliableTubes map[byte]*Unreliable
 
-	// Tube producers hand encoded frames to these queues. A successful send only
-	// means the Muxer sender accepted the frame; senderErr publishes completion
-	// after all accepted frames have either been written or discarded on error.
-	sendQueue         chan []byte
-	prioritySendQueue chan []byte
-	state             atomic.Value
+	// outbound is the only tube-to-Muxer admission path. Its queues are private
+	// to the Muxer sender and are never closed.
+	outbound *outbox
+	state    atomic.Value
+	// stopping is closed as soon as Stop wins lifecycle ownership. It wakes
+	// receiver-side admissions without waiting for shutdown completion.
+	stopping chan struct{}
 	// stopped is closed after Stop caches both worker results.
 	stopped    chan struct{}
 	underlying transport.MsgConn
 	timeout    time.Duration
 	log        *logrus.Entry
 
-	// senderErr receives once, after the sender has drained both send queues.
+	// senderErr receives once, after the sender stops or the transport write path fails.
 	senderErr chan error
 	sendErr   error
 
@@ -117,21 +118,21 @@ func newMuxer(msgConn transport.MsgConn, timeout time.Duration, isServer bool, l
 	}
 	state := atomic.Value{}
 	mux := &Muxer{
-		idParity:          idParity,
-		reliableTubes:     make(map[byte]*Reliable),
-		unreliableTubes:   make(map[byte]*Unreliable),
-		tubeQueue:         make(chan Tube, 128),
-		m:                 sync.Mutex{},
-		sendQueue:         make(chan []byte),
-		prioritySendQueue: make(chan []byte),
-		state:             state,
-		stopped:           make(chan struct{}),
-		underlying:        msgConn,
-		timeout:           timeout,
-		log:               log,
-		readBuf:           make([]byte, 65535),
-		receiverErr:       make(chan error),
-		senderErr:         make(chan error),
+		idParity:        idParity,
+		reliableTubes:   make(map[byte]*Reliable),
+		unreliableTubes: make(map[byte]*Unreliable),
+		tubeQueue:       make(chan Tube, 128),
+		m:               sync.Mutex{},
+		outbound:        newOutbox(),
+		state:           state,
+		stopping:        make(chan struct{}),
+		stopped:         make(chan struct{}),
+		underlying:      msgConn,
+		timeout:         timeout,
+		log:             log,
+		readBuf:         make([]byte, 65535),
+		receiverErr:     make(chan error, 1),
+		senderErr:       make(chan error, 1),
 	}
 
 	mux.state.Store(muxerRunning)
@@ -261,20 +262,20 @@ func (m *Muxer) makeReliableTubeWithID(tType TubeType, tubeID byte, req bool) (*
 		"tubeType": tType,
 	})
 	r := &Reliable{
-		id:                tubeID,
-		localAddr:         m.underlying.LocalAddr(),
-		remoteAddr:        m.underlying.RemoteAddr(),
-		tubeState:         created,
-		initRecv:          make(chan struct{}),
-		initDone:          make(chan struct{}),
-		sendDone:          make(chan struct{}),
-		closed:            make(chan struct{}, 1),
-		recvWindow:        newReceiver(tubeLog),
-		sender:            newSender(tubeLog),
-		sendQueue:         m.sendQueue,
-		prioritySendQueue: m.prioritySendQueue,
-		tType:             tType,
-		log:               tubeLog,
+		id:             tubeID,
+		localAddr:      m.underlying.LocalAddr(),
+		remoteAddr:     m.underlying.RemoteAddr(),
+		tubeState:      created,
+		initRecv:       make(chan struct{}),
+		initDone:       make(chan struct{}),
+		sendDone:       make(chan struct{}),
+		closed:         make(chan struct{}),
+		closeRequested: make(chan struct{}),
+		recvWindow:     newReceiver(tubeLog),
+		sender:         newSender(tubeLog),
+		outbound:       m.outbound,
+		tType:          tType,
+		log:            tubeLog,
 	}
 	r.lastAckSent.Store(0)
 	r.lastFrameSent.Store(0)
@@ -282,10 +283,6 @@ func (m *Muxer) makeReliableTubeWithID(tType TubeType, tubeID byte, req bool) (*
 	m.addTube(r)
 	go r.initiate(req)
 
-	if !req {
-		r.log.Debug("added tube to queue")
-		m.tubeQueue <- r
-	}
 	return r, nil
 }
 
@@ -319,7 +316,7 @@ func (m *Muxer) makeUnreliableTubeWithID(tType TubeType, tubeID byte, req bool) 
 	tube := &Unreliable{
 		tType:        tType,
 		id:           tubeID,
-		sendQueue:    m.sendQueue,
+		outbound:     m.outbound,
 		localAddr:    m.underlying.LocalAddr(),
 		remoteAddr:   m.underlying.RemoteAddr(),
 		recv:         common.NewDeadlineChan[[]byte](maxBufferedPackets),
@@ -340,10 +337,6 @@ func (m *Muxer) makeUnreliableTubeWithID(tType TubeType, tubeID byte, req bool) 
 	tube.state.Store(created)
 	go tube.initiate(req)
 
-	if !req {
-		tube.log.Debug("added tube to queue")
-		m.tubeQueue <- tube
-	}
 	return tube, nil
 }
 
@@ -351,11 +344,22 @@ func (m *Muxer) makeUnreliableTubeWithID(tType TubeType, tubeID byte, req bool) 
 // If the muxer stops, Accept will return a nil Tube and ErrMuxerStopping.
 // Otherwise, it will return a valid tube that is ready for use.
 func (m *Muxer) Accept() (Tube, error) {
-	tube, ok := <-m.tubeQueue
-	if !ok {
+	select {
+	case <-m.stopping:
+		return nil, ErrMuxerStopping
+	default:
+	}
+	select {
+	case tube := <-m.tubeQueue:
+		select {
+		case <-m.stopping:
+			return nil, ErrMuxerStopping
+		default:
+			return tube, nil
+		}
+	case <-m.stopping:
 		return nil, ErrMuxerStopping
 	}
-	return tube, nil
 }
 
 // readMsg reads a new packet from the underlying MsgConn. It then sets the timeout
@@ -374,49 +378,51 @@ func (m *Muxer) readMsg() (*frame, error) {
 
 }
 
-// sender accepts frames from the Muxer queues and writes them synchronously to
-// the underlying MsgConn. Receiving a frame is only a queue handoff; WriteMsg
-// completion is the point at which the transport has accepted it. If a write
-// fails, sender starts Stop and drains both queues so tube producers can exit.
+// sender is the sole receiver for outbox queues and the sole writer to the
+// underlying MsgConn. Failure aborts both admission priorities atomically.
 func (m *Muxer) sender() {
 	var err error
-	ok := true
-	var rawBytes []byte
-	for ok {
+	defer func() {
+		m.log.WithField("error", err).Debug("muxer sender stopped")
+		m.senderErr <- err
+	}()
+
+	for {
+		var rawBytes []byte
+		gotFrame := false
+
+		// Prefer priority traffic when it is already waiting without starving
+		// normal traffic when both arrive concurrently.
 		select {
-		// Priority send queue will have fewer packets and will be chosen pseudo randomly
-		// https://go.dev/ref/spec#Select_statements
-		case rawBytes, ok = <-m.prioritySendQueue:
-			if !ok {
-				break
-			}
-
-			err = m.underlying.WriteMsg(rawBytes)
-
-		case rawBytes, ok = <-m.sendQueue:
-			if !ok {
-				break
-			}
-
-			err = m.underlying.WriteMsg(rawBytes)
+		case rawBytes = <-m.outbound.priority:
+			gotFrame = true
+		default:
 		}
 
-		if err != nil {
-			m.log.Warnf("error in muxer sender. stopping muxer: %s", err)
-			// TODO(hosono) is it ok to stop the muxer here? Are the recoverable errors?
-			go m.Stop()
-			break
+		if !gotFrame {
+			select {
+			case <-m.outbound.aborted:
+				err = m.outbound.abortErr()
+				return
+			case <-m.outbound.stop:
+				return
+			case rawBytes = <-m.outbound.priority:
+				gotFrame = true
+			case rawBytes = <-m.outbound.normal:
+				gotFrame = true
+			}
 		}
-	}
 
-	// if we broke out of the loop, consume all packets so tubes can still close
-	for range m.sendQueue {
-	}
-	for range m.prioritySendQueue {
-	}
+		err = m.underlying.WriteMsg(rawBytes)
+		if err == nil {
+			continue
+		}
 
-	m.log.WithField("error", err).Debug("muxer sender stopped")
-	m.senderErr <- err
+		m.log.Warnf("error in muxer sender. stopping muxer: %s", err)
+		m.outbound.abort(err)
+		go m.Stop()
+		return
+	}
 }
 
 // start begins the sender and receiver goroutines
@@ -477,6 +483,14 @@ func (m *Muxer) receiver() {
 					m.m.Lock()
 					tube, _ = m.makeUnreliableTubeWithID(initFrame.tubeType, initFrame.tubeID, false)
 					m.m.Unlock()
+				}
+				if tube != nil {
+					tube.getLog().Debug("added tube to queue")
+					select {
+					case m.tubeQueue <- tube:
+					case <-m.stopping:
+						return
+					}
 				}
 			}
 		}
@@ -552,16 +566,18 @@ func (m *Muxer) Stop() (sendErr error, recvErr error) {
 	}
 
 	m.state.Store(muxerStopping)
+	close(m.stopping)
 	m.m.Unlock()
 
-	// If tubes do not correctly close after some time, assume they never will and force them to close.
-	time.AfterFunc(muxerTimeout, func() {
+	// If tubes do not correctly close after some time, abort admission before
+	// forcing lifecycle completion. This wakes both outbox priorities and any
+	// producer blocked behind a transport write.
+	fallback := time.AfterFunc(muxerTimeout, func() {
 		if m.state.Load() == muxerStopped {
 			return
 		}
 
-		// The graceful tube close may itself be blocked behind the Muxer sender.
-		// Close the transport first so sender can switch to draining its queues.
+		m.outbound.abort(ErrMuxerStopping)
 		m.underlying.Close()
 
 		m.m.Lock()
@@ -578,19 +594,19 @@ func (m *Muxer) Stop() (sendErr error, recvErr error) {
 
 	// Wait for all tubes to close
 	wg.Wait()
+	fallback.Stop()
 	m.state.Store(muxerStopped)
 
-	close(m.prioritySendQueue)
-	close(m.sendQueue)
-	close(m.tubeQueue)
+	m.outbound.requestStop()
 
-	// Drain every queued tube frame before closing the transport. If a transport
-	// write is stuck, Close must interrupt it so shutdown cannot deadlock.
+	// All tube producers have completed, so a graceful stop can terminate the
+	// sender without closing data queues. A blocked transport write is bounded.
 	senderTimer := time.NewTimer(muxerTimeout)
 	select {
 	case m.sendErr = <-m.senderErr:
 		senderTimer.Stop()
 	case <-senderTimer.C:
+		m.outbound.abort(ErrMuxerStopping)
 		m.underlying.Close()
 		m.sendErr = <-m.senderErr
 	}

--- a/tubes/muxer_test.go
+++ b/tubes/muxer_test.go
@@ -1,6 +1,7 @@
 package tubes
 
 import (
+	"errors"
 	"net"
 	"runtime"
 	"sync"
@@ -21,6 +22,9 @@ type blockingWriteMsgConn struct {
 	releaseWrite   chan struct{}
 	writeCompleted chan struct{}
 	closed         chan struct{}
+	reads          chan []byte
+	writes         chan []byte
+	writeErr       error
 
 	startOnce    sync.Once
 	completeOnce sync.Once
@@ -38,6 +42,8 @@ func newBlockingWriteMsgConn() *blockingWriteMsgConn {
 		releaseWrite:   make(chan struct{}),
 		writeCompleted: make(chan struct{}),
 		closed:         make(chan struct{}),
+		reads:          make(chan []byte, 16),
+		writes:         make(chan []byte, 16),
 	}
 }
 
@@ -79,24 +85,141 @@ func (c *blockingWriteMsgConn) SetWriteDeadline(time.Time) error {
 	return nil
 }
 
-func (c *blockingWriteMsgConn) ReadMsg([]byte) (int, error) {
-	<-c.closed
-	return 0, net.ErrClosed
+func (c *blockingWriteMsgConn) ReadMsg(b []byte) (int, error) {
+	select {
+	case msg := <-c.reads:
+		return copy(b, msg), nil
+	case <-c.closed:
+		return 0, net.ErrClosed
+	}
 }
 
-func (c *blockingWriteMsgConn) WriteMsg([]byte) error {
+func (c *blockingWriteMsgConn) WriteMsg(b []byte) error {
 	c.startOnce.Do(func() {
 		close(c.writeStarted)
 	})
 
 	select {
 	case <-c.releaseWrite:
+		c.writes <- append([]byte(nil), b...)
 		c.completeOnce.Do(func() {
 			close(c.writeCompleted)
 		})
-		return nil
+		return c.writeErr
 	case <-c.closed:
 		return net.ErrClosed
+	}
+}
+
+func TestMuxerSenderPrefersWaitingPriorityFrame(t *testing.T) {
+	conn := newBlockingWriteMsgConn()
+	close(conn.releaseWrite)
+	o := newOutbox()
+	// Buffer exactly one frame at each priority so both are waiting before the
+	// sender chooses. The queues remain owned by the Muxer under test.
+	o.normal = make(chan []byte, 1)
+	o.priority = make(chan []byte, 1)
+	muxer := &Muxer{
+		outbound:   o,
+		underlying: conn,
+		senderErr:  make(chan error, 1),
+		log:        logrus.WithField("test", t.Name()),
+	}
+	assert.NilError(t, o.enqueue(outboundFrame{bytes: []byte("data")}, nil))
+	assert.NilError(t, o.enqueue(outboundFrame{bytes: []byte("retransmission"), priority: true}, nil))
+	go muxer.sender()
+
+	assert.DeepEqual(t, <-conn.writes, []byte("retransmission"))
+	assert.DeepEqual(t, <-conn.writes, []byte("data"))
+	o.requestStop()
+	select {
+	case err := <-muxer.senderErr:
+		assert.NilError(t, err)
+	case <-time.After(time.Second):
+		t.Fatal("Muxer sender did not observe graceful stop")
+	}
+}
+
+func TestMuxerTransportFailureWakesBothQueuePriorities(t *testing.T) {
+	want := errors.New("injected transport write failure")
+	conn := newBlockingWriteMsgConn()
+	conn.writeErr = want
+	muxer := newMuxer(conn, 0, false, logrus.WithField("test", t.Name()))
+
+	assert.NilError(t, muxer.outbound.enqueue(outboundFrame{bytes: []byte("in flight")}, nil))
+	<-conn.writeStarted
+
+	started := make(chan struct{}, 2)
+	results := make(chan error, 2)
+	for _, priority := range []bool{false, true} {
+		go func() {
+			started <- struct{}{}
+			results <- muxer.outbound.enqueue(outboundFrame{bytes: []byte("waiting"), priority: priority}, nil)
+		}()
+	}
+	<-started
+	<-started
+	runtime.Gosched()
+	close(conn.releaseWrite)
+
+	for range 2 {
+		select {
+		case err := <-results:
+			assert.Assert(t, errors.Is(err, want))
+		case <-time.After(time.Second):
+			t.Fatal("transport failure did not wake both queue priorities")
+		}
+	}
+
+	stopDone := make(chan stopResult, 1)
+	go func() {
+		sendErr, recvErr := muxer.Stop()
+		stopDone <- stopResult{sendErr: sendErr, recvErr: recvErr}
+	}()
+	select {
+	case result := <-stopDone:
+		assert.Assert(t, errors.Is(result.sendErr, want))
+		assert.NilError(t, result.recvErr)
+	case <-time.After(time.Second):
+		t.Fatal("Muxer shutdown did not complete after transport failure")
+	}
+}
+
+func TestMuxerStopUnblocksFullRemoteTubeQueue(t *testing.T) {
+	conn := newBlockingWriteMsgConn()
+	muxer := newMuxer(conn, 0, false, logrus.WithField("test", t.Name()))
+	for range cap(muxer.tubeQueue) {
+		muxer.tubeQueue <- nil
+	}
+	conn.reads <- (&initiateFrame{
+		tubeID:   2,
+		tubeType: common.ExecTube,
+		flags:    frameFlags{REQ: true, REL: true},
+	}).toBytes()
+
+	deadline := time.Now().Add(time.Second)
+	for {
+		_, created := muxer.getTube(true, 2)
+		if created {
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatal("Muxer receiver did not reach the full remote-tube queue")
+		}
+		runtime.Gosched()
+	}
+
+	stopDone := make(chan stopResult, 1)
+	go func() {
+		sendErr, recvErr := muxer.Stop()
+		stopDone <- stopResult{sendErr: sendErr, recvErr: recvErr}
+	}()
+	select {
+	case result := <-stopDone:
+		assert.NilError(t, result.sendErr)
+		assert.NilError(t, result.recvErr)
+	case <-time.After(time.Second):
+		t.Fatal("Muxer.Stop deadlocked behind a full remote-tube queue")
 	}
 }
 
@@ -106,7 +229,7 @@ func TestMuxerStopDrainsSenderBeforeClosingUnderlying(t *testing.T) {
 	conn := newBlockingWriteMsgConn()
 	muxer := newMuxer(conn, time.Second, false, logrus.WithField("test", t.Name()))
 
-	muxer.sendQueue <- []byte("final reliable acknowledgement")
+	assert.NilError(t, muxer.outbound.enqueue(outboundFrame{bytes: []byte("final reliable acknowledgement")}, nil))
 	<-conn.writeStarted
 
 	stopDone := make(chan stopResult, 1)
@@ -153,7 +276,7 @@ func TestMuxerStopInterruptsBlockedSender(t *testing.T) {
 	conn := newBlockingWriteMsgConn()
 	muxer := newMuxer(conn, time.Second, false, logrus.WithField("test", t.Name()))
 
-	muxer.sendQueue <- []byte("blocked write")
+	assert.NilError(t, muxer.outbound.enqueue(outboundFrame{bytes: []byte("blocked write")}, nil))
 	<-conn.writeStarted
 
 	stopDone := make(chan stopResult, 1)
@@ -201,10 +324,10 @@ func TestMuxerStopUnblocksTubeProducerOnBlockedWrite(t *testing.T) {
 	err = tube.WriteMsg([]byte("queued behind blocked muxer write"))
 	assert.NilError(t, err)
 	deadline := time.Now().Add(time.Second)
-	for len(tube.send.C) != 0 && time.Now().Before(deadline) {
+	for tube.send.Len() != 0 && time.Now().Before(deadline) {
 		runtime.Gosched()
 	}
-	assert.Equal(t, len(tube.send.C), 0, "tube sender did not consume queued message")
+	assert.Equal(t, tube.send.Len(), 0, "tube sender did not consume queued message")
 
 	stopDone := make(chan stopResult, 1)
 	go func() {

--- a/tubes/muxer_test.go
+++ b/tubes/muxer_test.go
@@ -2,6 +2,7 @@ package tubes
 
 import (
 	"errors"
+	"io"
 	"net"
 	"runtime"
 	"sync"
@@ -34,6 +35,64 @@ type blockingWriteMsgConn struct {
 type stopResult struct {
 	sendErr error
 	recvErr error
+}
+
+// singleReadMsgConn returns one scripted message and then EOF. It lets receiver
+// tests exercise a complete dispatch iteration without starting a full Muxer or
+// leaving its receiver blocked on transport input.
+type singleReadMsgConn struct {
+	*blockingWriteMsgConn
+	message []byte
+	read    bool
+}
+
+func newSingleReadMsgConn(message []byte) *singleReadMsgConn {
+	return &singleReadMsgConn{
+		blockingWriteMsgConn: newBlockingWriteMsgConn(),
+		message:              message,
+	}
+}
+
+func (c *singleReadMsgConn) ReadMsg(b []byte) (int, error) {
+	if c.read {
+		return 0, io.EOF
+	}
+	c.read = true
+	return copy(b, c.message), nil
+}
+
+// gatedWriteMsgConn reports each selected frame before allowing WriteMsg to
+// return. While the Muxer sender is parked in WriteMsg, tests can
+// deterministically arrange waiting producers on the production unbuffered
+// outbox queues.
+type gatedWriteMsgConn struct {
+	*blockingWriteMsgConn
+	writeCalls chan []byte
+	release    chan struct{}
+}
+
+func newGatedWriteMsgConn() *gatedWriteMsgConn {
+	return &gatedWriteMsgConn{
+		blockingWriteMsgConn: newBlockingWriteMsgConn(),
+		writeCalls:           make(chan []byte),
+		release:              make(chan struct{}),
+	}
+}
+
+func (c *gatedWriteMsgConn) WriteMsg(b []byte) error {
+	written := append([]byte(nil), b...)
+	select {
+	case c.writeCalls <- written:
+	case <-c.closed:
+		return net.ErrClosed
+	}
+
+	select {
+	case <-c.release:
+		return nil
+	case <-c.closed:
+		return net.ErrClosed
+	}
 }
 
 func newBlockingWriteMsgConn() *blockingWriteMsgConn {
@@ -109,6 +168,141 @@ func (c *blockingWriteMsgConn) WriteMsg(b []byte) error {
 	case <-c.closed:
 		return net.ErrClosed
 	}
+}
+
+func TestMuxerReceiverIgnoresRemoteRequestWhileStopping(t *testing.T) {
+	tests := []struct {
+		name     string
+		reliable bool
+	}{
+		{name: "Unreliable"},
+		{name: "Reliable", reliable: true},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			request := (&initiateFrame{
+				tubeID:   2,
+				tubeType: common.ExecTube,
+				flags:    frameFlags{REQ: true, REL: test.reliable},
+			}).toBytes()
+			conn := newSingleReadMsgConn(request)
+			stopping := make(chan struct{})
+			close(stopping)
+			muxer := &Muxer{
+				reliableTubes:   make(map[byte]*Reliable),
+				unreliableTubes: make(map[byte]*Unreliable),
+				tubeQueue:       make(chan Tube, 1),
+				stopping:        stopping,
+				underlying:      conn,
+				log:             logrus.WithField("test", t.Name()),
+				readBuf:         make([]byte, 65535),
+				receiverErr:     make(chan error, 1),
+			}
+			muxer.state.Store(muxerStopping)
+
+			recovered := make(chan any, 1)
+			go func() {
+				defer func() {
+					recovered <- recover()
+				}()
+				muxer.receiver()
+			}()
+
+			select {
+			case panicValue := <-recovered:
+				if panicValue != nil {
+					t.Fatalf("Muxer receiver panicked on a remote request after stopping: %v", panicValue)
+				}
+			case <-time.After(time.Second):
+				t.Fatal("Muxer receiver did not finish after its scripted input")
+			}
+
+			select {
+			case tube := <-muxer.tubeQueue:
+				t.Fatalf("Muxer receiver queued a tube after stopping: %#v", tube)
+			default:
+			}
+		})
+	}
+}
+
+func TestMuxerSenderDoesNotStarveNormalTraffic(t *testing.T) {
+	const maxConsecutivePriority = 8
+
+	conn := newGatedWriteMsgConn()
+	stopped := make(chan struct{})
+	close(stopped)
+	muxer := &Muxer{
+		outbound:   newOutbox(),
+		stopped:    stopped,
+		underlying: conn,
+		senderErr:  make(chan error, 1),
+		log:        logrus.WithField("test", t.Name()),
+	}
+	muxer.state.Store(muxerStopping)
+
+	var producers sync.WaitGroup
+	startProducer := func(frame outboundFrame, started chan<- struct{}) {
+		producers.Add(1)
+		go func() {
+			defer producers.Done()
+			started <- struct{}{}
+			_ = muxer.outbound.enqueue(frame, nil)
+		}()
+	}
+
+	go muxer.sender()
+	t.Cleanup(func() {
+		muxer.outbound.abort(errors.New("test cleanup"))
+		_ = conn.Close()
+		select {
+		case <-muxer.senderErr:
+		case <-time.After(time.Second):
+			t.Error("Muxer sender did not stop during cleanup")
+		}
+		producers.Wait()
+	})
+
+	primeStarted := make(chan struct{}, 1)
+	startProducer(outboundFrame{bytes: []byte("prime")}, primeStarted)
+	<-primeStarted
+	select {
+	case got := <-conn.writeCalls:
+		assert.DeepEqual(t, got, []byte("prime"))
+	case <-time.After(time.Second):
+		t.Fatal("Muxer sender did not select the priming frame")
+	}
+
+	// The sender is now blocked in the priming WriteMsg. Park one normal
+	// producer and enough priority producers to exceed the permitted burst.
+	producerCount := maxConsecutivePriority + 2
+	started := make(chan struct{}, producerCount)
+	startProducer(outboundFrame{bytes: []byte("normal")}, started)
+	for i := 0; i < producerCount-1; i++ {
+		startProducer(outboundFrame{bytes: []byte{byte(i)}, priority: true}, started)
+	}
+	for i := 0; i < producerCount; i++ {
+		<-started
+	}
+	// Every producer has reached its enqueue call while there is no outbox
+	// receiver. Yield until each has had an opportunity to park on its send.
+	for i := 0; i < producerCount; i++ {
+		runtime.Gosched()
+	}
+
+	for consecutivePriority := 0; consecutivePriority <= maxConsecutivePriority; consecutivePriority++ {
+		conn.release <- struct{}{}
+		select {
+		case got := <-conn.writeCalls:
+			if string(got) == "normal" {
+				return
+			}
+		case <-time.After(time.Second):
+			t.Fatal("Muxer sender did not select another waiting frame")
+		}
+	}
+
+	t.Fatalf("normal traffic was starved for more than %d consecutive priority frames", maxConsecutivePriority)
 }
 
 func TestMuxerSenderPrefersWaitingPriorityFrame(t *testing.T) {

--- a/tubes/outbox.go
+++ b/tubes/outbox.go
@@ -1,0 +1,113 @@
+package tubes
+
+import (
+	"errors"
+	"io"
+	"sync"
+)
+
+// outboundFrame is one tube-to-Muxer admission request. Only the Muxer sender
+// receives from the two outbox queues; producers cannot access or close them.
+type outboundFrame struct {
+	bytes    []byte
+	priority bool
+}
+
+// outbox owns cancellable admission to the Muxer sender. The data queues are
+// deliberately never closed: stop and abort are the only shutdown signals, so
+// a producer can never race a send with queue closure.
+type outbox struct {
+	normal   chan []byte
+	priority chan []byte
+
+	stop      chan struct{}
+	aborted   chan struct{}
+	stopOnce  sync.Once
+	abortOnce sync.Once
+
+	errMu sync.Mutex
+	// +checklocks:errMu
+	err error
+}
+
+func newOutbox() *outbox {
+	return &outbox{
+		normal:   make(chan []byte),
+		priority: make(chan []byte),
+		stop:     make(chan struct{}),
+		aborted:  make(chan struct{}),
+	}
+}
+
+// enqueue blocks until the Muxer sender admits frame or either the producer or
+// Muxer is canceled. No caller may hold a lifecycle lock while calling enqueue.
+func (o *outbox) enqueue(frame outboundFrame, producerCanceled <-chan struct{}) error {
+	queue := o.normal
+	if frame.priority {
+		queue = o.priority
+	}
+
+	select {
+	case <-o.aborted:
+		return o.abortErr()
+	case <-producerCanceled:
+		return o.cancellationErr(io.EOF)
+	case <-o.stop:
+		return o.cancellationErr(ErrMuxerStopping)
+	default:
+	}
+
+	select {
+	case <-o.aborted:
+		return o.abortErr()
+	case <-producerCanceled:
+		return o.cancellationErr(io.EOF)
+	case <-o.stop:
+		return o.cancellationErr(ErrMuxerStopping)
+	case queue <- frame.bytes:
+		return nil
+	}
+}
+
+// cancellationErr gives an already-published transport failure precedence over
+// graceful or producer cancellation. abort always happens before failure-driven
+// Stop begins, so all blocked priorities observe the causal error.
+func (o *outbox) cancellationErr(fallback error) error {
+	select {
+	case <-o.aborted:
+		return o.abortErr()
+	default:
+		return fallback
+	}
+}
+
+// requestStop asks the sender to exit after all tube producers have completed.
+// Stop is closed by the Muxer shutdown owner and is never used to drain queues.
+func (o *outbox) requestStop() {
+	o.stopOnce.Do(func() {
+		close(o.stop)
+	})
+}
+
+// abort publishes failure without waiting for either queue. It wakes producers
+// blocked on normal and priority admission at the same instant.
+func (o *outbox) abort(err error) {
+	if err == nil {
+		err = ErrMuxerStopping
+	}
+	o.abortOnce.Do(func() {
+		o.errMu.Lock()
+		o.err = err
+		o.errMu.Unlock()
+		close(o.aborted)
+	})
+}
+
+func (o *outbox) abortErr() error {
+	o.errMu.Lock()
+	defer o.errMu.Unlock()
+	if o.err == nil {
+		return errors.New("muxer outbound path aborted")
+	}
+	return o.err
+}

--- a/tubes/outbox_test.go
+++ b/tubes/outbox_test.go
@@ -1,0 +1,122 @@
+package tubes
+
+import (
+	"errors"
+	"io"
+	"sync"
+	"testing"
+	"time"
+
+	"gotest.tools/assert"
+)
+
+func waitForOutboxResult(t *testing.T, result <-chan error, message string) error {
+	t.Helper()
+	select {
+	case err := <-result:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal(message)
+		return nil
+	}
+}
+
+// TestOutboxCancellationCoversEveryFrameClass verifies that shutdown can wake
+// every kind of producer even when no Muxer sender is available to receive the
+// handoff. Priority is admission metadata, not a separate cancellation domain.
+func TestOutboxCancellationCoversEveryFrameClass(t *testing.T) {
+	initRequest := (&initiateFrame{
+		tubeID: 1,
+		flags:  frameFlags{REQ: true, REL: true},
+	}).toBytes()
+	initResponse := (&initiateFrame{
+		tubeID: 1,
+		flags:  frameFlags{RESP: true, REL: true},
+	}).toBytes()
+
+	tests := []struct {
+		name     string
+		frame    []byte
+		priority bool
+	}{
+		{name: "initiation request", frame: initRequest},
+		{name: "initiation response", frame: initResponse},
+		{name: "data", frame: (&frame{tubeID: 1, frameNo: 1, dataLength: 1, data: []byte{1}, flags: frameFlags{REL: true}}).toBytes()},
+		{name: "RTO retransmission", frame: (&frame{tubeID: 1, frameNo: 1, dataLength: 1, data: []byte{1}, flags: frameFlags{REL: true, RTR: true}}).toBytes(), priority: true},
+		{name: "priority retransmission", frame: (&frame{tubeID: 1, frameNo: 1, dataLength: 1, data: []byte{1}, flags: frameFlags{REL: true}}).toBytes(), priority: true},
+		{name: "ACK", frame: (&frame{tubeID: 1, frameNo: 2, flags: frameFlags{REL: true, ACK: true}}).toBytes()},
+		{name: "FIN", frame: (&frame{tubeID: 1, frameNo: 2, flags: frameFlags{REL: true, ACK: true, FIN: true}}).toBytes()},
+		{name: "final FIN ACK", frame: (&frame{tubeID: 1, frameNo: 3, ackNo: 3, flags: frameFlags{REL: true, ACK: true}}).toBytes()},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			o := newOutbox()
+			canceled := make(chan struct{})
+			started := make(chan struct{})
+			result := make(chan error, 1)
+			go func() {
+				close(started)
+				result <- o.enqueue(outboundFrame{bytes: test.frame, priority: test.priority}, canceled)
+			}()
+			<-started
+
+			select {
+			case err := <-result:
+				t.Fatalf("admission returned without a receiver or cancellation: %v", err)
+			default:
+			}
+			close(canceled)
+			assert.Assert(t, errors.Is(waitForOutboxResult(t, result, "canceled admission did not return"), io.EOF))
+		})
+	}
+}
+
+func TestOutboxAbortWakesNormalAndPriorityAdmissions(t *testing.T) {
+	o := newOutbox()
+	want := errors.New("transport write failed")
+	start := make(chan struct{})
+	started := make(chan struct{}, 2)
+	results := make(chan error, 2)
+	for _, priority := range []bool{false, true} {
+		go func() {
+			<-start
+			started <- struct{}{}
+			results <- o.enqueue(outboundFrame{bytes: []byte{1}, priority: priority}, nil)
+		}()
+	}
+	close(start)
+	<-started
+	<-started
+	o.abort(want)
+
+	for range 2 {
+		assert.Assert(t, errors.Is(waitForOutboxResult(t, results, "transport failure did not wake both admission priorities"), want))
+	}
+}
+
+func TestOutboxShutdownCannotRaceSendOnClosedQueue(t *testing.T) {
+	o := newOutbox()
+	o.requestStop()
+
+	const producers = 256
+	var wg sync.WaitGroup
+	errs := make(chan error, producers)
+	wg.Add(producers)
+	for i := range producers {
+		go func() {
+			defer wg.Done()
+			errs <- o.enqueue(outboundFrame{bytes: []byte{byte(i)}, priority: i%2 == 0}, nil)
+		}()
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		assert.Assert(t, errors.Is(err, ErrMuxerStopping))
+	}
+
+	// The owner never closes its data queues, even after both graceful stop and
+	// abort are published. Repeated calls remain idempotent and panic-free.
+	o.requestStop()
+	o.abort(errors.New("late abort"))
+}

--- a/tubes/receiver.go
+++ b/tubes/receiver.go
@@ -109,12 +109,7 @@ func (r *receiver) processIntoBuffer() bool {
 		}
 	}
 	if oldLen > r.fragments.Len() {
-		select {
-		case r.dataReady.C <- struct{}{}:
-			break
-		default:
-			break
-		}
+		r.dataReady.TrySend(struct{}{})
 	}
 	return fin
 }

--- a/tubes/reliable.go
+++ b/tubes/reliable.go
@@ -2,6 +2,7 @@ package tubes
 
 import (
 	"encoding/binary"
+	"errors"
 	"io"
 	"net"
 	"sync"
@@ -38,28 +39,34 @@ type Reliable struct {
 	id         byte
 	localAddr  net.Addr
 	remoteAddr net.Addr
-	// +checklocks:l
+	// +checklocksignore
 	sender     *sender
 	recvWindow *receiver
-	// Frames sent here have only been handed to the Muxer; the Muxer sender
-	// performs and publishes completion of the actual transport write.
-	sendQueue         chan []byte
-	prioritySendQueue chan []byte
+	// outbound is owned by the Muxer. Reliable never accesses or closes its raw
+	// queues; every handoff is cancellation-aware.
+	outbound *outbox
 	// +checklocks:l
 	tubeState state
 	// +checklocks:l
 	lastAckTimer  *time.Timer
-	lastAckSent   atomic.Uint32
-	lastFrameSent atomic.Uint32
-	unsend        uint16
+	lastAckSent   atomic.Uint32 // +checklocksignore
+	lastFrameSent atomic.Uint32 // +checklocksignore
+	// +checklocks:l
+	unsend uint16
 
 	// closed publishes completion of the lifecycle transition and sender drain.
 	closed chan struct{}
+	// closeRequested is independently publishable and wakes initiation without
+	// acquiring l. Normal FIN processing continues until terminal close.
+	closeRequested     chan struct{}
+	closeRequestedOnce sync.Once
+	// +checklocks:l
+	closeStarted bool
 	// initRecv publishes receipt of the peer's initiation frame.
 	initRecv chan struct{}
 	// initDone publishes termination of the initiation producer.
 	initDone chan struct{}
-	// sendDone publishes that all inner sender frames were handed to the Muxer.
+	// sendDone publishes that all locally prepared sender frames were handed to the Muxer.
 	// It does not mean that the Muxer wrote those frames to the transport.
 	sendDone chan struct{}
 	l        sync.Mutex
@@ -96,15 +103,19 @@ func (r *Reliable) initiate(req bool) {
 	initLoop:
 		for {
 			r.l.Lock()
-			switch r.tubeState {
-			case initiated:
-				r.l.Unlock()
+			state := r.tubeState
+			r.l.Unlock()
+			if state == initiated {
 				break initLoop
-			case created:
-				r.sendQueue <- p.toBytes()
-				r.l.Unlock()
-			default:
-				r.l.Unlock()
+			}
+			if state != created {
+				return
+			}
+
+			if err := r.outbound.enqueue(outboundFrame{bytes: p.toBytes()}, r.closeRequested); err != nil {
+				if !errors.Is(err, io.EOF) {
+					r.closeFromOutboundFailure()
+				}
 				return
 			}
 
@@ -112,14 +123,20 @@ func (r *Reliable) initiate(req bool) {
 			case <-ticker.C:
 				r.log.Info("init rto exceeded")
 			case <-r.initRecv:
-			case <-r.closed:
+			case <-r.closeRequested:
+				r.l.Lock()
+				initiatedNow := r.tubeState == initiated
+				r.l.Unlock()
+				if initiatedNow {
+					break initLoop
+				}
 				return
 			}
 		}
 	} else {
 		select {
 		case <-r.initRecv:
-		case <-r.closed:
+		case <-r.closeRequested:
 			return
 		}
 	}
@@ -134,7 +151,8 @@ func (r *Reliable) initiate(req bool) {
 	r.l.Unlock()
 }
 
-func (r *Reliable) sendOneFrame(pkt *frame, retransmission bool) {
+// +checklocks:r.l
+func (r *Reliable) prepareFrameLocked(pkt *frame, retransmission bool) (outboundFrame, bool) {
 	ackNo := r.recvWindow.getAck()
 	lastFrameNo := r.lastFrameSent.Load()
 	lastAckNo := r.lastAckSent.Load()
@@ -155,15 +173,11 @@ func (r *Reliable) sendOneFrame(pkt *frame, retransmission bool) {
 		(pkt.dataLength == 0 && (ackNo != lastAckNo || pkt.frameNo != lastFrameNo ||
 			retransmission || pkt.flags.FIN || pkt.flags.RESP))) || r.unsend == 10 { // based on best practices for TCP loss detection RFC5681 and RFC6675. Should be 3 but 10 has a better mitigation for spurious loss detection
 
-		if retransmission {
-			r.prioritySendQueue <- pkt.toBytes() // send in the reliable priority queue
-		} else {
-			r.sendQueue <- pkt.toBytes()
-		}
 		r.lastAckSent.Store(ackNo)
 		r.lastFrameSent.Store(pkt.frameNo)
 
 		r.unsend = 0
+		return outboundFrame{bytes: pkt.toBytes(), priority: retransmission}, true
 	} else {
 		r.unsend++
 	}
@@ -175,13 +189,15 @@ func (r *Reliable) sendOneFrame(pkt *frame, retransmission bool) {
 			"ack":     pkt.flags.ACK,
 			"fin":     pkt.flags.FIN,
 			"dataLen": pkt.dataLength,
-		}).Trace("handed packet to muxer")
+		}).Trace("prepared packet for muxer admission")
 	}
+	return outboundFrame{}, false
 }
 
 // Retransmission ACKs are extra packets to update the sender/receiver
-// on the last ackNo update. It uses the prioritySendQueue.
-func (r *Reliable) sendRetransmissionAck(lastFrameNo, ackNo uint32, tubeId byte) {
+// on the last ackNo update.
+// +checklocks:r.l
+func (r *Reliable) retransmissionAckLocked(lastFrameNo, ackNo uint32, tubeId byte) (outboundFrame, bool) {
 	rtrPkt := &frame{
 		frameNo: lastFrameNo,
 		data:    []byte{},
@@ -195,30 +211,32 @@ func (r *Reliable) sendRetransmissionAck(lastFrameNo, ackNo uint32, tubeId byte)
 		"Ack N°":   ackNo,
 	}).Trace("Retransmission of RTR ack")
 
-	// Uses the priority queue to retransmit faster
-	r.prioritySendQueue <- rtrPkt.toBytes()
+	return r.prepareFrameLocked(rtrPkt, true)
 }
 
-// send drains the Reliable sender queues into the Muxer queues. Closing
-// sendDone means every frame was handed off, not written to the transport.
+// send selects new data and retransmissions, then releases the lifecycle lock
+// before asking the Muxer outbox to admit them.
 func (r *Reliable) send() {
-	var pkt *frame
-	sendQueue := r.sender.sendQueue                 // +checklocksignore accessing channels is safe
-	prioritySendQueue := r.sender.prioritySendQueue // +checklocksignore accessing channels is safe
-	for sendQueue != nil || prioritySendQueue != nil {
+	defer func() {
+		r.log.Debug("send ended")
+		close(r.sendDone)
+	}()
+
+	for {
 		select {
-		// onTimeout sender
-		case <-r.sender.RetransmitTicker.C: // +checklocksignore accessing channels is safe
+		case <-r.sender.done:
+			return
+		case <-r.sender.RetransmitTicker.C:
 
 			r.l.Lock()
 			if r.sender.closed.Load() {
 				r.l.Unlock()
-				continue
+				return
 			}
 
 			numFrames := r.sender.framesToSend(true, 0)
-
 			rtoSent := false
+			outbound := make([]outboundFrame, 0, numFrames)
 
 			for i := 0; i < numFrames; i++ {
 				rtoFrame := &r.sender.frames[i]
@@ -242,7 +260,9 @@ func (r *Reliable) send() {
 					rtoFrame.queued = true
 				}
 
-				r.sendOneFrame(rtoFrame.frame, true)
+				if frame, ok := r.prepareFrameLocked(rtoFrame.frame, true); ok {
+					outbound = append(outbound, frame)
+				}
 
 				rtoSent = true
 			}
@@ -277,19 +297,25 @@ func (r *Reliable) send() {
 			}
 
 			r.sender.resetRetransmitTicker()
-
 			r.l.Unlock()
+			if err := r.admitOutbound(outbound, r.sender.done); err != nil {
+				if !errors.Is(err, io.EOF) {
+					r.closeFromOutboundFailure()
+				}
+				return
+			}
 
-		case <-r.sender.senderWindow.windowOpen: // +checklocksignore accessing channels is safe
+		case <-r.sender.senderWindow.windowOpen:
 			r.l.Lock()
 			if r.sender.closed.Load() {
 				r.l.Unlock()
-				continue
+				return
 			}
 			numFrames := r.sender.framesToSend(false, 0)
 			r.log.WithField("numFrames", numFrames).Trace("window open")
 
 			numQueued := 0
+			outbound := make([]outboundFrame, 0, numFrames)
 
 			for i := 0; i < len(r.sender.frames) && numQueued < numFrames; i++ {
 				windowFrame := &r.sender.frames[i]
@@ -302,44 +328,47 @@ func (r *Reliable) send() {
 
 					windowFrame.Time = time.Now()
 					windowFrame.queued = true
-
-					r.sender.sendQueue <- windowFrame.frame
-
 					r.sender.unacked++
+					if frame, ok := r.prepareFrameLocked(windowFrame.frame, false); ok {
+						outbound = append(outbound, frame)
+					}
 
 					numQueued++
 				}
 			}
 			r.l.Unlock()
-
-		case queuedPkt, ok := <-sendQueue: // +checklocksignore accessing channels is safe
-			if !ok {
-				sendQueue = nil
-				continue
+			if err := r.admitOutbound(outbound, r.sender.done); err != nil {
+				if !errors.Is(err, io.EOF) {
+					r.closeFromOutboundFailure()
+				}
+				return
 			}
-
-			// Do not block ACKs - Blocks frame transmission out of window open
-			pkt = queuedPkt
-			r.sendOneFrame(pkt, false)
-
-		case queuedPkt, ok := <-prioritySendQueue: // +checklocksignore accessing channels is safe
-			if !ok {
-				prioritySendQueue = nil
-				continue
-			}
-
-			pkt = queuedPkt
-			r.sendOneFrame(pkt, true)
 		}
 	}
-	r.log.Debug("send ended")
-	close(r.sendDone)
+}
+
+func (r *Reliable) admitOutbound(frames []outboundFrame, canceled <-chan struct{}) error {
+	for _, frame := range frames {
+		if err := r.outbound.enqueue(frame, canceled); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r *Reliable) closeFromOutboundFailure() {
+	go func() {
+		r.l.Lock()
+		defer r.l.Unlock()
+		r.enterClosedState()
+	}()
 }
 
 // receive is called by the muxer for each new packet
+//
+//nolint:gocyclo // The reliable protocol state machine is intentionally centralized here.
 func (r *Reliable) receive(pkt *frame) error {
 	r.l.Lock()
-	defer r.l.Unlock()
 
 	if common.Debug {
 		r.log.WithFields(logrus.Fields{
@@ -359,13 +388,17 @@ func (r *Reliable) receive(pkt *frame) error {
 				"state": r.tubeState,
 			}).Info("receive for tube in bad state")
 		}
-
+		r.l.Unlock()
 		return ErrBadTubeState
 	}
+	outbound := make([]outboundFrame, 0, 3)
+	closeAfterAdmission := false
 
 	if pkt.flags.RTR && !pkt.flags.ACK && pkt.dataLength > 0 {
 		newAck := r.recvWindow.getAck()
-		r.sendRetransmissionAck(pkt.ackNo, newAck, r.id)
+		if frame, ok := r.retransmissionAckLocked(pkt.ackNo, newAck, r.id); ok {
+			outbound = append(outbound, frame)
+		}
 	}
 
 	finProcessed, err := r.recvWindow.receive(pkt)
@@ -375,12 +408,18 @@ func (r *Reliable) receive(pkt *frame) error {
 		missingFrameNo, ackErr := r.sender.recvAck(pkt.ackNo)
 		if ackErr != nil {
 			r.enterClosedState()
+			r.l.Unlock()
 			return ackErr
 		}
 		if missingFrameNo != 0 {
 			r.sender.m.Lock()
-			r.sendFrameByNumberLocked(missingFrameNo)
+			missing := r.frameByNumberLocked(missingFrameNo)
 			r.sender.m.Unlock()
+			if missing != nil {
+				if frame, ok := r.prepareFrameLocked(missing, true); ok {
+					outbound = append(outbound, frame)
+				}
+			}
 		}
 	}
 
@@ -392,10 +431,10 @@ func (r *Reliable) receive(pkt *frame) error {
 			r.log.Debug("got ACK of FIN packet. going from finWait1 to finWait2")
 		case closing:
 			r.log.Debug("got ACK of FIN packet. going from closing to closed")
-			r.enterClosedState()
+			closeAfterAdmission = true
 		case lastAck:
 			r.log.Debug("got ACK of FIN packet. going from lastAck to closed")
-			r.enterClosedState()
+			closeAfterAdmission = true
 		}
 	}
 
@@ -410,18 +449,42 @@ func (r *Reliable) receive(pkt *frame) error {
 			r.log.Debug("got FIN packet. going from finWait1 to closing")
 		case finWait2:
 			r.log.Debug("got FIN packet. going from finWait2 to closed")
-			r.sender.sendEmptyPacket()
-			r.enterClosedState()
+			if ack := r.sender.emptyPacket(); ack != nil {
+				if frame, ok := r.prepareFrameLocked(ack, false); ok {
+					outbound = append(outbound, frame)
+				}
+			}
+			closeAfterAdmission = true
 		}
-		if r.tubeState != closed {
+		if !closeAfterAdmission {
 			r.log.Trace("sending ACK of FIN")
-			r.sender.sendEmptyPacket()
+			if ack := r.sender.emptyPacket(); ack != nil {
+				if frame, ok := r.prepareFrameLocked(ack, false); ok {
+					outbound = append(outbound, frame)
+				}
+			}
 		}
 	}
 
 	// ACK every data packet
-	if pkt.dataLength > 0 && r.tubeState != closed && !pkt.flags.FIN {
-		r.sender.sendEmptyPacket()
+	if pkt.dataLength > 0 && !closeAfterAdmission && !pkt.flags.FIN {
+		if ack := r.sender.emptyPacket(); ack != nil {
+			if frame, ok := r.prepareFrameLocked(ack, false); ok {
+				outbound = append(outbound, frame)
+			}
+		}
+	}
+
+	if closeAfterAdmission {
+		r.enterClosedStateWithFrames(outbound)
+		r.l.Unlock()
+		return err
+	}
+	r.l.Unlock()
+
+	if admitErr := r.admitOutbound(outbound, r.sender.done); admitErr != nil && !errors.Is(admitErr, io.EOF) {
+		r.closeFromOutboundFailure()
+		return admitErr
 	}
 
 	return err
@@ -440,28 +503,43 @@ func (r *Reliable) enterLastAckState() {
 
 // +checklocks:r.l
 func (r *Reliable) enterClosedState() {
-	if r.tubeState == closed {
+	r.enterClosedStateWithFrames(nil)
+}
+
+// enterClosedStateWithFrames begins terminal shutdown while locked, releases
+// the lifecycle lock for reserved final-frame admission and sender completion,
+// then publishes close completion. Reserved frames (notably the final FIN ACK)
+// are admitted before sender cancellation can discard them.
+// +checklocks:r.l
+func (r *Reliable) enterClosedStateWithFrames(frames []outboundFrame) {
+	if r.closeStarted {
 		return
 	}
-	// Reject every producer before closing sender queues. This remains visible
-	// while the lifecycle lock is released to wait for the sender to drain.
+	r.closeStarted = true
 	r.tubeState = closed
+	if r.closeRequested != nil {
+		r.closeRequestedOnce.Do(func() {
+			close(r.closeRequested)
+		})
+	}
 	if r.lastAckTimer != nil {
 		r.lastAckTimer.Stop()
 	}
 	waitForSender := r.sender.Close() == nil
 	r.recvWindow.Close()
-	if waitForSender {
-		r.l.Unlock()
-		<-r.sendDone
-		r.l.Lock()
+	r.l.Unlock()
+	if len(frames) > 0 && r.outbound != nil {
+		_ = r.admitOutbound(frames, nil)
 	}
+	if waitForSender {
+		<-r.sendDone
+	}
+	r.l.Lock()
 	close(r.closed)
 }
 
 func (r *Reliable) receiveInitiatePkt(pkt *initiateFrame) error {
 	r.l.Lock()
-	defer r.l.Unlock()
 
 	if common.Debug {
 		r.log.WithFields(logrus.Fields{
@@ -482,11 +560,13 @@ func (r *Reliable) receiveInitiatePkt(pkt *initiateFrame) error {
 		r.tubeState = initiated
 		if _, err := r.sender.recvAck(1); err != nil {
 			r.enterClosedState()
+			r.l.Unlock()
 			return err
 		}
 		close(r.initRecv)
 	}
 
+	var response []byte
 	if pkt.flags.REQ && r.tubeState != closed {
 		p := initiateFrame{
 			tubeID:     r.id,
@@ -502,7 +582,17 @@ func (r *Reliable) receiveInitiatePkt(pkt *initiateFrame) error {
 				FIN:  false,
 			},
 		}
-		r.sendQueue <- p.toBytes()
+		response = p.toBytes()
+	}
+	r.l.Unlock()
+
+	if response != nil {
+		if err := r.outbound.enqueue(outboundFrame{bytes: response}, r.closeRequested); err != nil {
+			if !errors.Is(err, io.EOF) {
+				r.closeFromOutboundFailure()
+			}
+			return err
+		}
 	}
 
 	return nil
@@ -572,19 +662,20 @@ func (r *Reliable) ReadMsgUDP(b, oob []byte) (n, oobn, flags int, addr *net.UDPA
 // local sender. It does not wait for sender drain or peer acknowledgement; use
 // WaitForClose for lifecycle completion.
 func (r *Reliable) Close() (err error) {
-	select {
-	case <-r.initDone:
-		break
-	case <-r.closed:
-		break
+	if r.closeRequested != nil {
+		r.closeRequestedOnce.Do(func() {
+			close(r.closeRequested)
+		})
 	}
+	<-r.initDone
 
 	r.l.Lock()
-	defer r.l.Unlock()
 
 	switch r.tubeState {
 	case created:
 		r.log.WithField("state", r.tubeState).Warn("tried to close tube in bad state")
+		r.enterClosedState()
+		r.l.Unlock()
 		return ErrBadTubeState
 	case initiated:
 		r.tubeState = finWait1
@@ -595,14 +686,16 @@ func (r *Reliable) Close() (err error) {
 		r.enterLastAckState()
 	default:
 		// In this case, Close() has already been called
+		r.l.Unlock()
 		return io.EOF
 	}
 
 	// Cancel all pending read and write operations
-	r.SetReadDeadline(time.Now())
+	r.recvWindow.dataReady.SetDeadline(time.Now())
 	r.sender.deadline = time.Now()
 
 	err = r.sender.sendFin()
+	r.l.Unlock()
 
 	return err
 }
@@ -675,7 +768,7 @@ func (r *Reliable) SetWriteDeadline(t time.Time) error {
 }
 
 // +checklocks:r.l
-func (r *Reliable) sendFrameByNumberLocked(frameNo uint32) {
+func (r *Reliable) frameByNumberLocked(frameNo uint32) *frame {
 	if common.Debug {
 		logrus.Debugf("Searching for frame %v to priority send it", frameNo)
 	}
@@ -683,27 +776,27 @@ func (r *Reliable) sendFrameByNumberLocked(frameNo uint32) {
 		if common.Debug {
 			logrus.Debugf("Frame list has less than %v frames", defaultWindowSize)
 		}
-		return
+		return nil
 	}
 	for i := 0; i < defaultWindowSize; i++ {
-		rtrFrameStruct := r.sender.frames[i]
+		rtrFrameStruct := &r.sender.frames[i]
 		if rtrFrameStruct.frameNo == frameNo && rtrFrameStruct.queued {
 			rtrFrameStruct.Time = time.Now()
-			r.sender.prioritySendQueue <- rtrFrameStruct.frame
 			if common.Debug {
 				logrus.Debugf("Frame %v found and prority sent", frameNo)
 			}
-			return
+			return rtrFrameStruct.frame
 		} else if rtrFrameStruct.frameNo > frameNo {
 			if common.Debug {
 				logrus.Debugf("Frame %v not found, frame number in the list are greater than the frameNo", frameNo)
 			}
-			return
+			return nil
 		}
 	}
 	if common.Debug {
 		logrus.Debugf("Frame %v not found in the frame list", frameNo)
 	}
+	return nil
 }
 
 // CanAcceptBytes is currently called every 10ms to copy data in the frames list

--- a/tubes/sender.go
+++ b/tubes/sender.go
@@ -58,10 +58,9 @@ type sender struct {
 	// the time after which writes will expire
 	deadline time.Time
 
-	// sendQueue and prioritySendQueue contain frames admitted by the reliable
-	// state machine but not necessarily handed to the Muxer or transport.
-	sendQueue         chan *frame
-	prioritySendQueue chan *frame
+	// done is closed by the owning Reliable after its lifecycle rejects every
+	// producer. It wakes the sender loop and blocked outbox admission.
+	done chan struct{}
 
 	m sync.Mutex
 
@@ -106,9 +105,8 @@ func newSender(log *logrus.Entry) *sender {
 			windowSize:           defaultWindowSize,
 			windowOpen:           make(chan struct{}, 1),
 		},
-		sendQueue:         make(chan *frame, 1024), // TODO(hosono) make this size 0
-		prioritySendQueue: make(chan *frame, 1024),
-		log:               log.WithField("sender", ""),
+		done: make(chan struct{}),
+		log:  log.WithField("sender", ""),
 	}
 }
 
@@ -341,16 +339,15 @@ func (s *sender) onLoss(ackNo uint32) uint32 {
 	return missingFrameNo
 }
 
-func (s *sender) sendEmptyPacket() {
+func (s *sender) emptyPacket() *frame {
 	if s.closed.Load() {
-		return
+		return nil
 	}
-	pkt := &frame{
+	return &frame{
 		dataLength: 0,
 		frameNo:    s.frameNo,
 		data:       []byte{},
 	}
-	s.sendQueue <- pkt
 }
 
 func (s *sender) framesToSend(rto bool, startIndex int) int {
@@ -381,8 +378,7 @@ func (s *sender) framesToSend(rto bool, startIndex int) int {
 func (s *sender) Close() error {
 	if s.closed.CompareAndSwap(false, true) {
 		s.RetransmitTicker.Stop()
-		close(s.sendQueue)
-		close(s.prioritySendQueue)
+		close(s.done)
 
 		return nil
 	}
@@ -415,23 +411,19 @@ func (s *sender) sendFin() error {
 
 	s.frameNo++
 
-	// To properly close the receiver
-	addToSendQueue := false
-
 	if len(s.frames) == 0 {
-		pkt.queued = true
-		s.unacked++
-		addToSendQueue = true
+		// Wake the Reliable sender below after the FIN is appended. The sender
+		// applies normal window ordering, so FIN cannot overtake accepted data.
+		select {
+		case s.senderWindow.windowOpen <- struct{}{}:
+		default:
+		}
 	}
 
 	s.frames = append(s.frames, struct {
 		*frame
 		time.Time
 	}{&pkt, time.Time{}})
-
-	if addToSendQueue {
-		s.sendQueue <- &pkt
-	}
 
 	return nil
 }

--- a/tubes/state_machine_test.go
+++ b/tubes/state_machine_test.go
@@ -2,6 +2,7 @@ package tubes
 
 import (
 	"testing"
+	"time"
 
 	"github.com/sirupsen/logrus"
 
@@ -219,23 +220,24 @@ func TestFinalFINAckIsSentBeforeClose(t *testing.T) {
 	const attempts = 128
 	for range attempts {
 		log := logrus.New().WithField("test", t.Name())
+		outbound, recorded := newRecordingOutbox(t)
 		s := newSender(log)
 		s.closed.Store(false)
 
 		initDone := make(chan struct{})
 		close(initDone)
 		r := &Reliable{
-			id:                1,
-			sender:            s,
-			recvWindow:        newReceiver(log),
-			sendQueue:         make(chan []byte, 1),
-			prioritySendQueue: make(chan []byte, 1),
-			tubeState:         finWait2,
-			closed:            make(chan struct{}),
-			initRecv:          make(chan struct{}),
-			initDone:          initDone,
-			sendDone:          make(chan struct{}),
-			log:               log,
+			id:             1,
+			sender:         s,
+			recvWindow:     newReceiver(log),
+			outbound:       outbound,
+			tubeState:      finWait2,
+			closed:         make(chan struct{}),
+			closeRequested: make(chan struct{}),
+			initRecv:       make(chan struct{}),
+			initDone:       initDone,
+			sendDone:       make(chan struct{}),
+			log:            log,
 		}
 		go r.send()
 
@@ -248,12 +250,12 @@ func TestFinalFINAckIsSentBeforeClose(t *testing.T) {
 		assert.NilError(t, err)
 
 		select {
-		case raw := <-r.sendQueue:
-			pkt, err := fromBytes(raw)
+		case admitted := <-recorded:
+			pkt, err := fromBytes(admitted.bytes)
 			assert.NilError(t, err)
 			assert.Check(t, pkt.flags.ACK)
 			assert.Equal(t, pkt.ackNo, uint32(1))
-		default:
+		case <-time.After(time.Second):
 			t.Fatal("final FIN ACK was discarded while stopping the sender")
 		}
 	}

--- a/tubes/tubes_test.go
+++ b/tubes/tubes_test.go
@@ -59,6 +59,10 @@ func (c *ProbabalisticUDPMsgConn) WriteMsg(b []byte) (err error) {
 // coin flipper. A value of 0 sends all packets, while larger values drop more
 // packets. rel is true for reliable tubes and false for unreliable ones.
 func makeConn(bits int, rel bool, t testing.TB) (t1, t2 net.Conn, stop func(), r bool, err error) {
+	return makeConnWithTimeout(bits, rel, time.Second, t)
+}
+
+func makeConnWithTimeout(bits int, rel bool, timeout time.Duration, t testing.TB) (t1, t2 net.Conn, stop func(), r bool, err error) {
 	r = rel
 	var c1, c2 transport.MsgConn
 	c2Addr, err := net.ResolveUDPAddr("udp", ":7777")
@@ -78,7 +82,7 @@ func makeConn(bits int, rel bool, t testing.TB) (t1, t2 net.Conn, stop func(), r
 	wg.Add(2)
 	go func() {
 		defer wg.Done()
-		muxer1 = newMuxer(c1, time.Second, false, logrus.WithFields(logrus.Fields{
+		muxer1 = newMuxer(c1, timeout, false, logrus.WithFields(logrus.Fields{
 			"muxer": "m1",
 			"test":  t.Name(),
 		}))
@@ -86,7 +90,7 @@ func makeConn(bits int, rel bool, t testing.TB) (t1, t2 net.Conn, stop func(), r
 	}()
 	go func() {
 		defer wg.Done()
-		muxer2 = newMuxer(c2, time.Second, true, logrus.WithFields(logrus.Fields{
+		muxer2 = newMuxer(c2, timeout, true, logrus.WithFields(logrus.Fields{
 			"muxer": "m2",
 			"test":  t.Name(),
 		}))
@@ -230,8 +234,6 @@ func lossyBasicIO(t *testing.T) {
 }
 
 func reliable(t *testing.T) {
-	logrus.SetLevel(logrus.TraceLevel)
-
 	t.Run("Close", func(t *testing.T) {
 		t.Run("Wait", func(t *testing.T) {
 			CloseTest(0, true, true, t)
@@ -252,7 +254,9 @@ func reliable(t *testing.T) {
 	})
 
 	f := func(t *testing.T) (c1, c2 net.Conn, stop func(), rel bool, err error) {
-		return makeConn(0, true, t)
+		// nettest owns operation deadlines and deliberately includes idle
+		// periods; an independent Muxer timeout changes its semantics.
+		return makeConnWithTimeout(0, true, 0, t)
 	}
 
 	mp := nettest.MakePipe(f)
@@ -265,8 +269,6 @@ func reliable(t *testing.T) {
 }
 
 func unreliable(t *testing.T) {
-	logrus.SetLevel(logrus.TraceLevel)
-
 	t.Run("Close", func(t *testing.T) {
 		t.Run("Wait", func(t *testing.T) {
 			CloseTest(0, false, true, t)
@@ -277,7 +279,7 @@ func unreliable(t *testing.T) {
 	})
 
 	f := func(t *testing.T) (c1, c2 net.Conn, stop func(), rel bool, err error) {
-		return makeConn(0, false, t)
+		return makeConnWithTimeout(0, false, 0, t)
 	}
 	mp := nettest.MakePipe(f)
 	t.Run("Nettest", func(t *testing.T) {

--- a/tubes/unreliable.go
+++ b/tubes/unreliable.go
@@ -17,9 +17,9 @@ import (
 type Unreliable struct {
 	tType TubeType
 	id    byte
-	// sendQueue hands encoded frames to the Muxer. A completed send does not
-	// imply that the frame has been written to the underlying transport.
-	sendQueue chan []byte
+	// outbound is owned by the Muxer; Unreliable cannot access or close its raw
+	// queues.
+	outbound *outbox
 
 	// Unreliable tubes can be in three states:
 	// created: Indicates the tube has been created and is waiting for the remote peer send back an initiate frame
@@ -48,6 +48,8 @@ type Unreliable struct {
 	send *common.DeadlineChan[[]byte]
 
 	frameNo atomic.Uint32 // +checklocks:lifecycleMu
+	// +checklocks:lifecycleMu
+	finishFrame []byte
 
 	localAddr  net.Addr
 	remoteAddr net.Addr
@@ -67,16 +69,32 @@ var _ transport.MsgConn = &Unreliable{}
 // Unreliable tubes are tubes
 var _ Tube = &Unreliable{}
 
-// sender drains the local queue into the Muxer queue. senderDone only means the
-// frames were handed off; the Muxer sender owns actual transport writes.
+// sender drains messages admitted before Close and then admits FIN. It never
+// holds lifecycleMu while the Muxer outbox can block.
 func (u *Unreliable) sender() {
-	for b := range u.send.C {
+	defer close(u.senderDone)
+	for {
+		b, err := u.send.RecvQueued()
+		if err != nil {
+			break
+		}
 		u.log.Trace("handing packet to muxer")
-		u.sendQueue <- b
+		if err := u.outbound.enqueue(outboundFrame{bytes: b}, nil); err != nil {
+			go u.Close()
+			return
+		}
 	}
 
+	u.lifecycleMu.Lock()
+	finishFrame := u.finishFrame
+	u.lifecycleMu.Unlock()
+	if finishFrame != nil {
+		if err := u.outbound.enqueue(outboundFrame{bytes: finishFrame}, nil); err != nil {
+			go u.Close()
+			return
+		}
+	}
 	u.log.Debug("sender ended")
-	close(u.senderDone)
 }
 
 func (u *Unreliable) makeInitFrame(req bool) initiateFrame {
@@ -107,16 +125,18 @@ func (u *Unreliable) initiate(req bool) {
 	initLoop:
 		for {
 			u.lifecycleMu.Lock()
-			switch u.state.Load() {
+			state := u.state.Load()
+			u.lifecycleMu.Unlock()
+			switch state {
 			case initiated:
-				u.lifecycleMu.Unlock()
 				break initLoop
 			case created:
 				p := u.makeInitFrame(req)
-				u.sendQueue <- p.toBytes()
-				u.lifecycleMu.Unlock()
+				if err := u.outbound.enqueue(outboundFrame{bytes: p.toBytes()}, u.stopInitiate); err != nil {
+					close(u.senderDone)
+					return
+				}
 			default:
-				u.lifecycleMu.Unlock()
 				close(u.senderDone)
 				return
 			}
@@ -130,8 +150,25 @@ func (u *Unreliable) initiate(req bool) {
 				return
 			}
 		}
+	} else {
+		// The Muxer starts responder initiation before it dispatches the peer's
+		// request. Wait for that request instead of racing the receiver and
+		// permanently exiting the sender when this goroutine runs first.
+		select {
+		case <-u.initiated:
+		case <-u.stopInitiate:
+			close(u.senderDone)
+			return
+		}
 	}
 
+	u.lifecycleMu.Lock()
+	started := u.state.Load() == initiated
+	u.lifecycleMu.Unlock()
+	if !started {
+		close(u.senderDone)
+		return
+	}
 	go u.sender()
 }
 
@@ -147,32 +184,34 @@ func (u *Unreliable) receiveInitiatePkt(pkt *initiateFrame) error {
 		"state":   u.state.Load(),
 	}).Debug("receiving initiate packet")
 
-	if u.state.CompareAndSwap(created, initiated) {
+	u.lifecycleMu.Lock()
+	if u.state.Load() == created {
+		u.state.Store(initiated)
 		close(u.initiated)
 	}
 
 	// Send a RESP packet in response to REQ packets
-	u.lifecycleMu.Lock()
-	defer u.lifecycleMu.Unlock()
+	var response []byte
 	if pkt.flags.REQ && u.state.Load() != closed {
 		u.log.Trace("handing RESP packet to muxer")
 		p := u.makeInitFrame(false)
-		u.sendQueue <- p.toBytes()
+		response = p.toBytes()
+	}
+	u.lifecycleMu.Unlock()
+
+	if response != nil {
+		return u.outbound.enqueue(outboundFrame{bytes: response}, u.stopInitiate)
 	}
 
 	return nil
 }
 
 func (u *Unreliable) receive(pkt *frame) error {
-	u.lifecycleMu.Lock()
-	defer u.lifecycleMu.Unlock()
 	if u.state.Load() == closed {
 		return ErrBadTubeState
 	}
 
-	select {
-	case u.recv.C <- pkt.data:
-	default:
+	if !u.recv.TrySend(pkt.data) {
 		return nil
 	}
 	if pkt.flags.FIN {
@@ -237,13 +276,14 @@ func (u *Unreliable) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int,
 	}
 
 	u.lifecycleMu.Lock()
-	defer u.lifecycleMu.Unlock()
 	if u.state.Load() == closed {
+		u.lifecycleMu.Unlock()
 		return 0, 0, io.EOF
 	}
 
 	dataLength := uint16(len(b))
 	if uint16(len(b)) > MaxFrameDataLength {
+		u.lifecycleMu.Unlock()
 		err = transport.ErrBufOverflow
 		return n, oobn, err
 	}
@@ -264,6 +304,7 @@ func (u *Unreliable) WriteMsgUDP(b, oob []byte, addr *net.UDPAddr) (n, oobn int,
 		queued:     false,
 	}
 	u.frameNo.Add(1)
+	u.lifecycleMu.Unlock()
 
 	err = u.send.Send(pkt.toBytes())
 	if err != nil {
@@ -287,17 +328,6 @@ func (u *Unreliable) Close() error {
 		u.lifecycleMu.Unlock()
 		return io.EOF
 	}
-	u.lifecycleMu.Unlock()
-
-	if oldState == created {
-		close(u.stopInitiate)
-	}
-	<-u.initiateDone
-
-	u.lifecycleMu.Lock()
-	defer u.lifecycleMu.Unlock()
-
-	var err error
 	if oldState == initiated {
 		pkt := frame{
 			tubeID: u.id,
@@ -315,19 +345,22 @@ func (u *Unreliable) Close() error {
 			queued:     false,
 		}
 		u.frameNo.Add(1)
-		err = u.send.Send(pkt.toBytes())
+		u.finishFrame = pkt.toBytes()
 	}
+	u.lifecycleMu.Unlock()
 
-	u.send.Close()
-	u.recv.Close()
-
-	close(u.send.C)
+	if oldState == created {
+		close(u.stopInitiate)
+	}
+	_ = u.send.Close()
+	<-u.initiateDone
 
 	<-u.senderDone
 
+	_ = u.recv.Close()
 	close(u.closed)
 
-	return err
+	return nil
 }
 
 // LocalAddr implements net.Conn


### PR DESCRIPTION
## Summary

This fixes the GOMAXPROCS=1 tubes liveness regression introduced/exposed by #195 by replacing raw outbound channel handoffs with a Muxer-owned, cancellable admission abstraction.

The change also hardens DeadlineChan close ordering, removes lifecycle locks from blocking operations, makes Muxer failure/shutdown wake every producer, fixes unreliable responder initiation ordering, separates stop-request publication from stop completion, corrects the net.Conn harness, documents concurrency invariants, and adds mechanical enforcement plus deterministic race tests.

## Root cause

The original unreliable deadlock was a cancellation inversion:

1. Unreliable.WriteMsgUDP held lifecycleMu.
2. It blocked in DeadlineChan.Send after the 1,000-packet local queue filled.
3. Unreliable.Close needed lifecycleMu before it could publish closure.
4. Close therefore could not cancel the write it was waiting on.

The same structural issue existed at other tube-to-Muxer handoffs: producers could block on raw normal/priority channels while lifecycle progress depended on those producers. The Muxer sender's failure path tried to drain channels whose closure depended on upstream shutdown, and closing raw data queues admitted send-on-closed races. #195 made Close wait for lifecycle completion correctly, exposing these older ownership/cancellation cycles under one-P scheduling.

The audit also found two independent ordering bugs:

- an unreliable responder could run its initiation goroutine before the receiver published the request and exit its sender permanently;
- a receiver blocked on a full remote-tube accept queue waited for stopped, while Stop waited for the receiver before publishing stopped.

## Architecture

- Added a private Muxer outbox with normal and priority admission, producer cancellation, graceful stop, and failure abort. Its data queues are never closed.
- The Muxer sender is the sole reader of raw outbound queues and sole writer to the transport. A transport write failure publishes abort before starting Stop, waking both priorities with the causal error.
- Added a distinct stopping broadcast for Accept and remote-tube admission; stopped remains completion publication for concurrent Stop callers.
- DeadlineChan now hides its raw channel, registers senders only under a short admission mutex, publishes close cancellation before waiting for registered senders, preserves pre-close buffered values, and provides TrySend/RecvQueued for nonblocking producers and owning drains.
- Reliable prepares state-machine frames while locked, unlocks before outbox admission, reserves the final FIN ACK before terminal sender cancellation, and uses independently publishable close/init cancellation.
- Unreliable releases lifecycleMu before DeadlineChan.Send/outbox admission, rejects writers before draining accepted data, and admits FIN last.
- Transport receive loops use DeadlineChan.TrySend while holding session state, so queue pressure drops a datagram instead of blocking lifecycle progress.

## Explicit concurrency invariants

1. Lifecycle/state locks protect bounded in-memory transitions only; they never span channel waits, wait-group waits, queue admission, or socket I/O.
2. Cancellation can always be published without acquiring a mutex held by the operation it must cancel.
3. Only the Muxer sender receives outbound raw queues and writes the underlying transport.
4. Raw data queues are never closed; stop/abort broadcasts carry shutdown.
5. Shutdown proceeds producer-to-consumer: reject new work, join tube producers, request sender stop, then close transport.
6. Final reliable FIN acknowledgement admission precedes terminal close publication.

make vet now runs internal/checkblockinglocks in addition to checklocks. The new checker rejects known blocking channel, queue, wait, and socket operations while lifecycle/state mutexes are held.

## Why GOMAXPROCS=1 is required

Correct Go channel cancellation and net.Conn.Close behavior cannot depend on true parallel execution. One-P scheduling is the strongest deterministic pressure on handoff ordering: a goroutine blocked while retaining the cancellation lock prevents the only runnable closer from making progress. The fix establishes cancellation/ownership ordering rather than weakening the tests or requiring more processors.

## Harness fixes

- nettest Muxers use no independent idle timeout; nettest owns deadlines and deliberate idle periods.
- Existing non-nettest helpers retain their one-second Muxer timeout.
- Removed global trace logging from reliable/unreliable suites so output volume no longer materially perturbs one-P scheduling.

## Current draft status

Commit `76ccd35` adds two intentionally failing regression tests at current HEAD:

- `TestMuxerReceiverIgnoresRemoteRequestWhileStopping` recovers and reports the typed-nil panic for both Reliable and Unreliable remote requests after shutdown begins.
- `TestMuxerSenderDoesNotStarveNormalTraffic` uses the production unbuffered outbox and reports normal traffic starved by more than eight consecutive priority frames.

The implementation fixes for these two regressions have not yet been applied. The validation below records the previously green implementation commit `6f8034c`; current HEAD is intentionally red until both tests pass.

## Validation at 6f8034c

- [x] make format
- [x] make build
- [x] make lint using the workflow-pinned golangci-lint v2.2.2: 0 issues
- [x] make vet (checkblockinglocks plus checklocks)
- [x] make test
- [x] make test-concurrency: 10 shuffled race runs each for transport, tubes, and hoptests at GOMAXPROCS=1,2,4
- [x] supplied shuffle 1786561583740982486 under GOMAXPROCS=1 and -race
- [x] supplied shuffle 1786574488354091922 under GOMAXPROCS=1 and -race
- [x] deterministic DeadlineChan close/concurrent-close tests repeated 100 times under GOMAXPROCS=1 and -race
- [x] deterministic outbound admission, priority/failure, initiation, backpressure, concurrent-close, final-FIN-ACK, and send-after-stop tests repeated 50 times under GOMAXPROCS=1 and -race
- [x] raw-channel ownership/bypass audit: only outbox creates outbound queues; only Muxer sender receives them; no production raw DeadlineChan access remains
- [x] built and ran real hopd and hop binaries together locally: UDP handshake, certificate validation, Muxer startup, and user-auth tube exchange completed

## Limitations / notes

- Full remote command execution in the local binary smoke test is blocked by an existing macOS portability issue: server user lookup parses /etc/passwd, while the active macOS Open Directory user is not present there. The failure occurred after transport/tubes establishment and is an application/platform limitation, not a sandbox or concurrency failure.
- The locally installed golangci-lint v2.12.2 reports seven pre-existing prealloc warnings in cyclist/portforwarding on both this branch and an untouched main worktree. The CI-pinned v2.2.2 target passes with zero issues.
- DeadlineChan's backing C field is intentionally no longer exported; callers must use Send, TrySend, Recv, or RecvQueued so admission remains tracked.
- checkblockinglocks is deliberately syntactic and covers the known blocking operations in tubes/transport; checklocks remains responsible for protected-field correctness.
